### PR TITLE
[2022/09/28] design/SpotWeatherInfoViewRainInfoLabelSetupAttributedString >> BbajiSpotViewController rainInfoLabel Attributed String 적용하기

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
@@ -155,10 +155,14 @@ extension SpotWeatherInfoView: UICollectionViewDelegate, UICollectionViewDataSou
 
 extension SpotWeatherInfoView {
     func makeTimeAsBlackColor(label: UILabel, time: Int) {
+        // label 전체 텍스트의 기본 컬러를 bbagaGray2로 설정
         let attributedString = NSMutableAttributedString(string: label.text ?? "", attributes: [NSAttributedString.Key.foregroundColor: UIColor.bbagaGray2])
+        // label 일부분에 입힐 컬러를 bbagaGray1으로 설정
         let blackTextColorAttribute = [NSAttributedString.Key.foregroundColor: UIColor.bbagaGray1]
 
+        // 현재 시간(매개변수로 받은 time)의 자릿수에 따라 bbagaGray1 색상을 입힐 텍스트의 범위값을 다르게 설정
         attributedString.addAttributes(blackTextColorAttribute, range: NSRange(location:0, length: time / 10 == 0 ? 5 : 6))
+        // label에 Color 입히기
         label.attributedText = attributedString
     }
 }


### PR DESCRIPTION
## 작업사항
- BbajiSpotViewController의 SpotWeatherInfoView rainInfoLabel 텍스트의 일부분만 색상을 다르게 만드는 메소드 작성

```
func makeTimeAsBlackColor(label: UILabel, time: Int) {
        // label 전체 텍스트의 기본 컬러를 bbagaGray2로 설정
        let attributedString = NSMutableAttributedString(string: label.text ?? "", attributes: [NSAttributedString.Key.foregroundColor: UIColor.bbagaGray2])
        // label 일부분에 입힐 컬러를 bbagaGray1으로 설정
        let blackTextColorAttribute = [NSAttributedString.Key.foregroundColor: UIColor.bbagaGray1]

        // 현재 시간(매개변수로 받은 time)의 자릿수에 따라 bbagaGray1 색상을 입힐 텍스트의 범위값을 다르게 설정
        attributedString.addAttributes(blackTextColorAttribute, range: NSRange(location:0, length: time / 10 == 0 ? 5 : 6))
        // label에 Color 입히기
        label.attributedText = attributedString
    }
```
**Test Code**
- SpotWeatherInfoView.swift의 line88에 넣어 테스트할 수 있습니다.
```
makeTimeAsBlackColor(label: rainInfoLabel, time: 12)
```
|테스트 결과|
|:---:|
|<img width="300" alt="스크린샷 2022-09-28 오전 5 25 45" src="https://user-images.githubusercontent.com/96641477/192628423-4daf5f9d-9f6d-4553-981e-d0d843049e0c.png">|


## 이슈번호
#22 

## 특이사항(Optional)
- makeTimeAsBlackColor의 매개변수 `time`의 경우, 추후 Date()를 통해 받아온 현재 시각을 기준으로 값이 정해질 예정입니다.

Close #22