### PR TITLE
[2022/10/02] fix/BbajiSpotViewControllerAddScrollViewArea >> Bbaji 정보 관련 뷰 스크롤뷰 내부로 편입

### DIFF
--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -10,8 +10,8 @@ import SnapKit
 
 final class BbajiSpotViewController: UIViewController {
     private let liveCameraView = SpotLiveCameraView()
-    private let scrollContentView = UIView()
     private let infoScrollView = UIScrollView()
+    private let infoScrollContentView = UIView()
     private let spotInfoView = SpotInfoView()
     private let spotWeatherInfoView = SpotWeatherInfoView()
     
@@ -50,10 +50,8 @@ final class BbajiSpotViewController: UIViewController {
             make.bottom.equalTo(safeArea.snp.bottom)
         })
         
-        scrollView.addSubview(scrollContentView)
-        scrollContentView.snp.makeConstraints({ make in
-            make.top.equalTo(scrollView.snp.top)
-            make.bottom.equalTo(scrollView.snp.bottom)
+        infoScrollView.addSubview(infoScrollContentView)
+        infoScrollContentView.snp.makeConstraints({ make in
             make.top.equalTo(infoScrollView.snp.top)
             make.bottom.equalTo(infoScrollView.snp.bottom)
             make.centerX.equalTo(safeArea.snp.centerX)
@@ -65,19 +63,19 @@ final class BbajiSpotViewController: UIViewController {
         [
             spotInfoView,
             spotWeatherInfoView
-        ].forEach({ scrollContentView.addSubview($0) })
+        ].forEach({ infoScrollContentView.addSubview($0) })
 
         spotInfoView.snp.makeConstraints({ make in
-            make.top.equalTo(scrollContentView.snp.top).inset(viewToViewMargin)
-            make.leading.equalTo(scrollContentView.snp.leading).inset(defaultMargin)
-            make.trailing.equalTo(scrollContentView.snp.trailing).inset(defaultMargin)
+            make.top.equalTo(infoScrollContentView.snp.top).inset(viewToViewMargin)
+            make.leading.equalTo(infoScrollContentView.snp.leading).inset(defaultMargin)
+            make.trailing.equalTo(infoScrollContentView.snp.trailing).inset(defaultMargin)
             make.height.equalTo(166)
         })
 
         spotWeatherInfoView.snp.makeConstraints({ make in
             make.top.equalTo(spotInfoView.snp.bottom).offset(viewToViewMargin)
-            make.leading.equalTo(scrollContentView.snp.leading).inset(defaultMargin)
-            make.trailing.equalTo(scrollContentView.snp.trailing).inset(defaultMargin)
+            make.leading.equalTo(infoScrollContentView.snp.leading).inset(defaultMargin)
+            make.trailing.equalTo(infoScrollContentView.snp.trailing).inset(defaultMargin)
             make.height.equalTo(306)
         })
 


### PR DESCRIPTION
## 작업사항
1. BbajiSpotViewController의 SpotInfoView, SpotWeatherInfoView를 스크롤뷰 내부로 편입

|시연 영상|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/193421453-3beac9a0-8074-48d0-a866-9c2c18722f50.mp4)|

## 이슈번호
#30 

## 특이사항(Optional)
- Figma 기준 디자인 레이아웃이 iPhone13에 맞춰진 상태로, iPhone Pro Max 기종의 경우, 하단의 일부 영역이 남게되는 문제점을 확인했습니다. 추후 레이아웃의 수정이 필요할 가능성이 있습니다.

|iPhone 11 Pro Max 예시 자료|
|:---:|
|![Simulator Screen Shot - iPhone 11 Pro Max - 2022-10-02 at 02 39 39](https://user-images.githubusercontent.com/96641477/193421521-2ed256f2-4cd8-426a-8850-74ee7a7dea7f.png)|

Close #30 