### PR TITLE
[2022/10/02] style/SpotWeatherInfoViewReviseLabelName >> currentWeatherLabel -> currentTemperatureLabel로 이름 변경

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
@@ -52,9 +52,9 @@ final class SpotWeatherInfoView: UIView {
         })
         
         let currentWeatherIcon = UIImageView()
-        let currentWeatherLabel = UILabel()
+        let currentTemperatureLabel = UILabel()
         
-        [currentWeatherIcon, currentWeatherLabel].forEach({
+        [currentWeatherIcon, currentTemperatureLabel].forEach({
             currentWeatherIconAndLabel.addSubview($0)
         })
         
@@ -65,15 +65,15 @@ final class SpotWeatherInfoView: UIView {
             make.width.height.equalTo(64)
         })
         
-        currentWeatherLabel.snp.makeConstraints({ make in
+        currentTemperatureLabel.snp.makeConstraints({ make in
             make.leading.equalTo(currentWeatherIcon.snp.trailing).offset(CGFloat.iconOffset)
             make.centerY.equalTo(currentWeatherIcon.snp.centerY)
             make.width.equalTo(100)
         })
         
-        labelSetting(label: currentWeatherLabel, text: "23°", font: .bbajiFont(.heading1), alignment: .center)
+        labelSetting(label: currentTemperatureLabel, text: "23°", font: .bbajiFont(.heading1), alignment: .center)
         
-        currentWeatherLabel.textColor = .bbagaGray1
+        currentTemperatureLabel.textColor = .bbagaGray1
         
         let rainInfoLabel = UILabel()
         self.addSubview(rainInfoLabel)


### PR DESCRIPTION
## 작업사항
BbajiSpotViewController 하위의 SpotWeatherInfoView의 Label 이름을 변경
**currentWeatherLabel -> currentTemperatureLabel**
- 현재 온도에 관한 정보를 나타내는 Label이므로 위와 같이 수정했습니다.

## 이슈번호
#34 

Close #34 