### PR TITLE
[2022/10/02] feat/BbajiSpotViewControllerSpotLiveCameraViewAddLandscape >> SpotLiveCameraView 전체화면 시 Landscape 모드 전환 추가

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
@@ -10,7 +10,7 @@ import AVKit
 
 final class SpotLiveCameraView: UIView {
     private var player: AVPlayer?
-    var avpController = AVPlayerViewController()
+    var avpController = RotatableAVPlayerViewController()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -28,5 +28,21 @@ final class SpotLiveCameraView: UIView {
         avpController.view.frame.size.width = size.width
         self.addSubview(avpController.view)
         player?.play()
+    }
+
+}
+
+class RotatableAVPlayerViewController: AVPlayerViewController {
+    
+    override var shouldAutorotate: Bool {
+        return false
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+             return .landscapeRight
+          }
+    
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        return .landscapeRight
     }
 }


### PR DESCRIPTION
## 작업사항
- BbajiSpotViewController의 상부에 위치한 SpotLiveCameraView가 전체화면 진입 시, Portrait -> Landscape 모드로 전환되는 기능을 추가

|시도|결과|
|:---|:---|
|1차 시도: AVPlayerViewController의 FullScreen 모드 전환 관련 Delegate에서 UIOrientationMask 변경| 영상의 전체화면으로의 변경이 먼저 이루어져, Default (Portrait) -> Full Screen (Landscape) 전환이 제대로 작동하지 않음 -> 실패|
|2차 시도: BbajiSpotViewController의 UIOrientationmask를 Landscape로 제한|Full Screen 모드 뿐만이 아닌, Default 모드에서도 Landscape 모드로 있어 뷰가 깨지는 문제가 발생 -> 실패|
|3차 시도: AVPlayerViewController를 상속받는 RotatableAVPlayerViewController를 작성 후, UIOrientationMask를 Landscape(Right)로 제한| 정상적으로 작동하지만 한계점을 지님. 한계점은 아래의 영상을 통해 확인 가능. 또한 공식 다큐먼트에서 해설하기를 _"The framework doesn’t support subclassing AVPlayerViewController."_ 문장을 미루어볼 때 좋은 방법은 아닌 것으로 추측됨.

![](https://user-images.githubusercontent.com/96641477/193450032-1d3672d4-fc09-4ad6-8e4e-88e931c677f5.mp4)

**한계점**
- Default -> Full Screen으로 상태 변경 시, Portrait -> Landscape 전환이 자연스럽게 이루어지지 않음
- 한계점 해결을 위한 지속적인 리서치 필요

## 이슈번호
#38 

Close #38 