### PR TITLE
[2022/10/02] feat/uiOrientationPortraitOnlyRestriction >> UIInterfaceOrientationMask Portrait Only로 제한

### DIFF
--- a/BJGG/BJGG/AppDelegate.swift
+++ b/BJGG/BJGG/AppDelegate.swift
@@ -10,7 +10,9 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait
+    }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.


### PR DESCRIPTION
## 작업사항
- UIInterfaceOrientationMask를 Portrait Only로 제한
- AppDelegate 내부 코드로 처리

|시연 영상|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/193450578-85ab05d2-d9f4-4e5c-8b4a-3295d9a911bb.mov)|

## 이슈번호
#42 

Close #42 