### PR TITLE
[2022/10/02] feat/bbajiSpotViewControllerSpotInfoViewAddressLabelAddNoticeAnimation >> SpotInfoView Address Label 클립 보드 복사 Notice 애니메이션 구현

### DIFF
--- a/BJGG/BJGG/Extension/UILabel+CopyLabelText.swift
+++ b/BJGG/BJGG/Extension/UILabel+CopyLabelText.swift
@@ -18,5 +18,50 @@ extension UILabel {
     @objc func copyLabelText(_ sender: UITapGestureRecognizer) {
         guard let label = sender.view as? UILabel else { return }
         UIPasteboard.general.string = label.text
+        showToastMessage()
+    }
+    
+    func showToastMessage() {
+        let width = UIScreen.main.bounds.width
+        let height = UIScreen.main.bounds.height
+        
+        let toastLabel = UILabel()
+        
+        let margin = CGFloat.superViewInset * 1.4
+        
+        // Case: Opacity 조정
+        toastLabel.frame = CGRect(x: margin, y: height * 0.88, width: width - margin * 2, height: 45)
+        
+        // Case: Position 조정
+//        toastLabel.frame = CGRect(x: margin, y: height * 1.12, width: width - margin * 2, height: 45)
+        toastLabel.text = "클립보드에 복사되었습니다."
+        toastLabel.textColor = UIColor.bbagaGray4
+        toastLabel.backgroundColor = UIColor.bbagaGray1
+        toastLabel.textAlignment = .center
+        toastLabel.layer.cornerRadius = 4
+        toastLabel.clipsToBounds = true
+        toastLabel.isUserInteractionEnabled = false
+        toastLabel.layer.opacity = 0
+        self.window?.rootViewController?.view.addSubview(toastLabel)
+        
+        // Case: Opacity 조정
+        UIView.animate(withDuration: 0.4, delay: 0, options: .curveEaseOut, animations: {
+            toastLabel.layer.opacity = 1
+        }, completion: {_ in
+            UIView.animate(withDuration: 0.4, delay: 0.3, options: .curveEaseOut, animations: {
+                toastLabel.layer.opacity = 0
+            })
+        })
+        
+        // Case: Position 조정
+//        toastLabel.layer.opacity = 1
+//        UIView.animate(withDuration: 0.4, delay: 0, options: .curveEaseOut, animations: {
+//            toastLabel.frame = CGRect(x: margin, y: height * 0.88, width: width - margin * 2, height: 45)
+//        }, completion: {_ in
+//            UIView.animate(withDuration: 0.4, delay: 0.6, options: .curveEaseOut, animations: {
+//                toastLabel.frame = CGRect(x: margin, y: height * 1.12, width: width - margin * 2, height: 45)
+//            })
+//        })
+
     }
 }


### PR DESCRIPTION
## 작업사항
- BbajiSpotViewController SpotInfoView의 Address Label 터치 시, 클립보드 복사가 되었음을 명시적으로 확인할 수 있는 UILabel(이하, Toast Message) Animation을 추가
- 2022.10.02 기준 일자로 Opacity 조정 케이스와 Frame 위치 조정 케이스 두 가지로 애니메이션이 구성되어 있습니다.
-> Toast Message의 출현 형태는 화요일 회의를 통해 확정될 예정입니다.
-> Toast Message의 width, height, frame, color, textColor etc 설정값 또한 화요일 회의를 통해 확정될 예정입니다.

|Case: Opacity 조정|Case: Frame Position 조정|
|:---:|:---:|
|![](https://user-images.githubusercontent.com/96641477/193457572-025ea50f-d371-4575-aab8-dacd9df891b1.mov)|![](https://user-images.githubusercontent.com/96641477/193457567-b6306cb8-b41b-40d1-a18d-bf7b3724dbba.mov)|

- 각각의 Case는 UILabel+CopyLabelText.swift 내부의 주석 처리문을 통해 확인할 수 있습니다.

## 이슈번호
#39

## 특이사항(Optional)
- func showToastMessage()의 경우 UILabel의 Extension에 속하기보다는 따로 구분되어 사용되어야하는 메소드로 추측되어지나, 현재 Label에 TapGesture을 부여하는 작업과 관련된 메소드가 UILabel+CopyLabelText에 속해 있는 관계로 해당 Extension에 넣었습니다.
- **추후 Refactor를 통해 메소드의 위치가 수정되어야합니다.**

Close #39 