### PR TITLE
[2022/10/04] fix/bbajiInfoStructUpdate >> BbajiInfo Struct 내부 property 추가 및 메소드 수정

### DIFF
--- a/BJGG/BJGG/Model/BbajiInfo.swift
+++ b/BJGG/BJGG/Model/BbajiInfo.swift
@@ -14,6 +14,8 @@ struct BbajiInfo: Encodable {
     private var address: String
     private var contact: String
     private var compactAddress: String
+    private var coordinateX: Int
+    private var coordinateY: Int
     private var liveCameraURL: String
     
     // Quick Test Init
@@ -23,15 +25,19 @@ struct BbajiInfo: Encodable {
         address = "서울 광진구 강변북로64"
         contact = "02-498-9026"
         compactAddress = "광진구 자양동"
+        coordinateX = 61
+        coordinateY = 126
         liveCameraURL = "https://offtoriver.shop/hls/waterskii.m3u8"
     }
     
-    init(name: String, thumbnailImgName: String, address: String, contact: String, liveCamURL: String) {
+    init(name: String, thumbnailImgName: String, address: String, contact: String, compactAddress: String, coordinateX: Int, coordinateY: Int, liveCamURL: String) {
         self.name = name
         self.thumbnailImgName = thumbnailImgName
         self.address = address
         self.contact = contact
         self.compactAddress = compactAddress
+        self.coordinateX = coordinateX
+        self.coordinateY = coordinateY
         self.liveCameraURL = liveCamURL
     }
     
@@ -44,6 +50,9 @@ struct BbajiInfo: Encodable {
     func getContact() -> String { return contact }
     
     func getCompactAddress() -> String { return compactAddress }
+    
+    func getCoordinate() -> (Int, Int) { return (coordinateX, coordinateY) }
+    
     func getLiveCameraUrl() -> String { return liveCameraURL }
     
 }


### PR DESCRIPTION
## 작업사항
날씨 API 관련 작업을 위해 BbajiInfo의 Property를 추가합니다
- compactAddress: BbajiSpotViewController에서 사용되는 축약된 주소지 정보 String 타입의 값
```
private var compactAddress: String
```
- CoordinateX, CoordinateY: 업체의 위치값을 받아오기 위한 Int 타입의 값
```
private var coordinateX: Int
private var coordinateY: Int
```
- private property들을 들고오기 위한 메소드 추가
```
func getCompactAddress() -> String { return compactAddress }
func getCoordinate() -> (Int, Int) { return (coordinateX, coordinateY) }
```
- 추가적으로 기존에 잘못된 형태로 들고오던 addressLabel, contactLabel 관련 메소드의 return 값을 수정합니다.
```
 func getAddress() -> String { return address }
func getContact() -> String { return contact }
```
## 이슈번호
#55 

## 특이사항(Optional)
- BbajiInfo 기반으로 View 내부의 Component 요소들을 호출하는 작업이 필요합니다.

Close #55 
