### PR TITLE
[2022/10/04] feat/weatherItemsSortMethod >> WeatherItems 모델의 현재시간 별 데이터 sort 메소드 구현

### DIFF
--- a/BJGG/BJGG/Model/Weather.swift
+++ b/BJGG/BJGG/Model/Weather.swift
@@ -237,6 +237,46 @@ struct WeatherItems: Decodable {
         
         return filteredItem
     }
+    
+    func request24HourWeatherItem() -> [WeatherItem] {
+        var filteredItem = [WeatherItem]()
+        
+        var current: (day: String, time: Int) {
+            let now = Date()
+            let formatter = DateFormatter()
+            formatter.dateFormat = "yyyyMMdd HHmm"
+            formatter.locale = Locale(identifier: "ko_kr")
+            formatter.timeZone = TimeZone(abbreviation: "KST")
+
+            let currentDayAndTime = formatter.string(from: now).split(separator: " ")
+            let currentDay = String(currentDayAndTime[0])
+            let time = Int(currentDayAndTime[1])!
+
+            let calculatedTime = (time / 100) * 100
+
+            if calculatedTime < 1000 {
+                return (currentDay, calculatedTime)
+            } else {
+                return (currentDay, calculatedTime)
+            }
+        }
+        
+        item.forEach {
+            if $0.category == "TMP" || $0.category == "SKY" || $0.category == "POP" || $0.category == "PTY" {
+                if $0.fcstDate == current.day {
+                    if current.time <= Int($0.fcstTime)! {
+                        filteredItem.append($0)
+                    }
+                } else {
+                    if Int($0.fcstTime)! <= current.time {
+                        filteredItem.append($0)
+                    }
+                }
+            }
+        }
+        
+        return filteredItem
+    }
 }
 
 struct WeatherBody: Decodable {


### PR DESCRIPTION
## 작업사항
1. WeatherItems 구조체에서 item 상수를 현재시간 별 필요한 데이터(온도, 하늘상태, 강수상태, 강수확률)를 sort하여 반환하는 requestCurrentWeatherItem() 메소드를 구현하였습니다.
2. WeatherItems 구조체에서 item 상수를 현재시간 기준으로 24시간까지의 데이터만 제공할 수 있도록 sort하여 반환하는 request24HourWeatherItem() 메소드를 구현하였습니다.

## 이슈번호
- #49 

## 특이사항
### ❗️사용방법 및 주의사항❗️
1. WeatherManager에서 **현재시간의 데이터(requestCurrentData)** 를 호출할 땐  requestCurrentWeatherItem() 메소드를 사용하세요.
<img width="572" alt="current" src="https://user-images.githubusercontent.com/83946704/193663925-2ab4270f-ca78-4582-be0e-57aa8c2291b3.png">

2. WeatherManager에서 **현재시간으로부터 24시간의 데이터(request24hData)** 를 호출할 땐  request24HourWeatherItem() 메소드를 사용하세요.
<img width="546" alt="24hourUse" src="https://user-images.githubusercontent.com/83946704/193664004-b5e17333-4d23-47d2-b595-b35d6d7bb9b5.png">

close #49 