### PR TITLE
[2022/10/04] fix/weatherManagerRequest24hData >> WeatherManager의 request24hData 메소드의 데이터 호출갯수 오류 수정

### DIFF
--- a/BJGG/BJGG/Model/WeatherManager.swift
+++ b/BJGG/BJGG/Model/WeatherManager.swift
@@ -69,7 +69,7 @@ struct WeatherManager {
     }
     
     func request24hData(nx: Int, ny: Int, completionHandler: @escaping (Bool, Any) -> Void) {
-        requestData(nx: nx, ny: ny, numberOfRow: 312) { (success, data) in
+        requestData(nx: nx, ny: ny, numberOfRow: 324) { (success, data) in
             completionHandler(success, data)
         }
     }


### PR DESCRIPTION
## 작업사항
1. WeatherManager의 request24hData 메소드의 날씨 데이터 호출갯수가 312개일 때 현재시간 기준으로 23시간 이후까지의 데이터만 불러오던 오류를 데이터 호출개수를 324개로 수정한 후 현재시간 기준으로 24시간 이후까지의 데이터를 불러오도록 수정하였습니다.

## 이슈번호
- #62 

## 특이사항(Optional)
함수 사용에 변경된 점은 없습니다. 기존과 같이 사용하면 됩니다.

close #62 
