### PR TITLE
[2022/10/04] fix/BbajiSpotViewControllerSpotWeatherInfoViewCellWeatherAPIFix >> SpotWeatherInfoView Cell 현재 시간 시작값 수정 로직 적용

### DIFF
--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -94,10 +94,10 @@ final class BbajiSpotViewController: UIViewController {
                 return
             }
             
-            let data = response.body.items
-            for i in 0...data.item.count-1 {
-                if data.item[i].category == "TMP" {
-                    timeNTempInfo.append((time: data.item[i].timeValue, temperature: data.item[i].fcstValue))
+            let data = response.body.items.request24HourWeatherItem()
+            for i in 0...data.count-1 {
+                if data[i].category == "TMP" {
+                    timeNTempInfo.append((time: data[i].timeValue, temperature: data[i].fcstValue))
                 }
             }
             


### PR DESCRIPTION
## 작업사항
- PR #54 한계점을 PR #58 에서 해결하여, 이를 SpotWeatherInfoView에 반영했습니다.
```
// BbajiSpotViewController.swift
let data = response.body.items.request24HourWeatherItem()
    for i in 0...data.count-1 {
        if data[i].category == "TMP" {
            timeNTempInfo.append((time: data[i].timeValue, temperature: data[i].fcstValue))
        }
    }
```

|반영 결과|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/193677453-60a866a0-e227-422c-82de-79bcdd5cad7d.mov)|

## 이슈번호
#61

Close #61 