### PR TITLE
[2022/10/04] fix/bbajiSpotViewControllerSpotWeatherInfoViewCurrentTemperatureLabelChangeValue >> 시간 및 온도 Label Setting Text 값 수정

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
@@ -164,8 +164,10 @@ extension SpotWeatherInfoView: UICollectionViewDelegate, UICollectionViewDataSou
         labelSetting(label: cell.currentRainPercentLabel, text: "60%", font: .bbajiFont(.rainyCaption), alignment: .center)
         cell.currentRainPercentLabel.textColor = .bbagaRain
         
-        labelSetting(label: cell.temperatureLabel, text: "23°", font: .bbajiFont(.heading5), alignment: .center)
-        labelSetting(label: cell.timeLabel, text: "오후12시", font: .bbajiFont(.body1), alignment: .center)
+        let temperatureStr = "\(currentTimeNTemperatureInfo[idx].temperature)°"
+        let timeStr = currentTimeNTemperatureInfo[idx].time
+        labelSetting(label: cell.temperatureLabel, text: temperatureStr, font: .bbajiFont(.heading5), alignment: .center)
+        labelSetting(label: cell.timeLabel, text: timeStr, font: .bbajiFont(.body1), alignment: .center)
         if idx == 0 {
             cell.temperatureLabel.font = UIFont(name: UIFont.Pretendard.bold.rawValue, size: 20.0) ?? UIFont()
             cell.timeLabel.font = UIFont(name: UIFont.Pretendard.bold.rawValue, size: 15.0) ?? UIFont()


### PR DESCRIPTION
## 작업사항
- PR #58의 결과로 수정되었던 API호출 방식을 제대로 호출했으나 (아래의 형태로 반영)
```
// BbajiSpotViewController.swift
let weatherManager = WeatherManager()
        weatherManager.request24hData(nx: 61, ny: 126) { success, response in
            guard let response = response as? Response else {
                print("Error: API 호출 실패")
                return
            }
            
            let data = response.body.items.request24HourWeatherItem()
            for i in 0...data.count-1 {
                if data[i].category == "TMP" {
                    timeNTempInfo.append((time: data[i].timeValue, temperature: data[i].fcstValue))
                }
            }
// 이하 생략
```
- 실제 Label의 text 초기화 과정에서는 임의의 더미 데이터를 통해 관리하고 있었기 때문에 발생한 문제로 확인됨
- 이전 PR에서 해결했었으나, Conflict 해소 과정에서 반영할 코드 선정에서 Text Value 값들을 들고오지 않았기 때문에 발생한 문제로도 확인됨
**이전 코드**
```
// SpotWeatherInfoView.swift
labelSetting(label: cell.temperatureLabel, text: "23°", font: .bbajiFont(.heading5), alignment: .center)
labelSetting(label: cell.timeLabel, text: "오후12시", font: .bbajiFont(.body1), alignment: .center)
```
**바뀐 코드**
```
let temperatureStr = "\(currentTimeNTemperatureInfo[idx].temperature)°"
let timeStr = currentTimeNTemperatureInfo[idx].time
labelSetting(label: cell.temperatureLabel, text: temperatureStr, font: .bbajiFont(.heading5), alignment: .center)
labelSetting(label: cell.timeLabel, text: timeStr, font: .bbajiFont(.body1), alignment: .center)
```


|반영 전|반영 결과|
|:---:|:---:|
|![](https://user-images.githubusercontent.com/96641477/193810959-b51ef4e0-5b63-44d7-9459-06453923a93d.mov)|![](https://user-images.githubusercontent.com/96641477/193810656-d764c839-b16a-4d93-a2a1-5c50c401d246.mov)

## 이슈번호
#72 

Close #72 