### PR TITLE
[2022/10/04] fix/bbajiSpotViewControllerSpotInfoViewAddressLabelAnimationConfirm >> SpotInfoViewAddressLabel의 Animation 확정

### DIFF
--- a/BJGG/BJGG/Extension/UILabel+CopyLabelText.swift
+++ b/BJGG/BJGG/Extension/UILabel+CopyLabelText.swift
@@ -29,11 +29,8 @@ extension UILabel {
         
         let margin = CGFloat.superViewInset * 1.4
         
-        // Case: Opacity 조정
         toastLabel.frame = CGRect(x: margin, y: height * 0.88, width: width - margin * 2, height: 45)
-        
-        // Case: Position 조정
-//        toastLabel.frame = CGRect(x: margin, y: height * 1.12, width: width - margin * 2, height: 45)
+
         toastLabel.text = "클립보드에 복사되었습니다."
         toastLabel.textColor = UIColor.bbagaGray4
         toastLabel.backgroundColor = UIColor.bbagaGray1
@@ -44,7 +41,6 @@ extension UILabel {
         toastLabel.layer.opacity = 0
         self.window?.rootViewController?.view.addSubview(toastLabel)
         
-        // Case: Opacity 조정
         UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut, animations: {
             toastLabel.layer.opacity = 0.9
         }, completion: {_ in
@@ -52,16 +48,6 @@ extension UILabel {
                 toastLabel.layer.opacity = 0
             })
         })
-        
-        // Case: Position 조정
-//        toastLabel.layer.opacity = 1
-//        UIView.animate(withDuration: 0.4, delay: 0, options: .curveEaseOut, animations: {
-//            toastLabel.frame = CGRect(x: margin, y: height * 0.88, width: width - margin * 2, height: 45)
-//        }, completion: {_ in
-//            UIView.animate(withDuration: 0.4, delay: 0.6, options: .curveEaseOut, animations: {
-//                toastLabel.frame = CGRect(x: margin, y: height * 1.12, width: width - margin * 2, height: 45)
-//            })
-//        })
 
     }
 }


### PR DESCRIPTION
## 작업사항
- 기존의 Issue #39 및 PR #46 에서 처리했던 **SpotInfoView의 Address Label의 애니메이션 효과를 Opacity변경으로 확정
- AddressLabel Position 변경 Animation 주석 삭제
**기존 시퀀스와 변경된 시퀀스는 아래와 같습니다.**

|Label Opacity Value|Max - Min|
|:---|:---:|
|변경 전|1.0 - 0.0|
|변경 후|0.9 - 0.0|

- SpotInfoView Address Label Animation 효과의 시퀀스는 아래와 같습니다.

|Sequence|변경 전 - 변경 후 Value|
|:---|:---:|
|Label Appear|0.4 Second - 0.3 Second|
|Label Sustain|0.6 Second - 0.6 Second|
|Label Disappear|0.4 Second - 0.5 Second|


|반영 결과|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/193844517-6f7f7858-3535-4c0e-bc33-0db47b0837e6.mov)|

## 이슈번호
#78

Close #78