### PR TITLE
[2022/10/04] #82 fix/BbajiSpotViewControllerInfoScrollContentViewReviseHeightForPhysicalHomeButtonDevice >> 물리 홈버튼을 가진 기종을 위한 InfoScrollContentView 높이값 수정

### DIFF
--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -55,7 +55,7 @@ final class BbajiSpotViewController: UIViewController {
             make.bottom.equalTo(infoScrollView.snp.bottom)
             make.centerX.equalTo(safeArea.snp.centerX)
             make.width.equalTo(safeArea.snp.width)
-            make.height.equalTo(508)
+            make.height.equalTo(UIDevice.current.hasNotch ? 508 : 508 - 32)
         })
         infoScrollView.showsVerticalScrollIndicator = false
         


### PR DESCRIPTION
## 작업사항
- 물리 홈버튼을 가진 기종을 위해 BbajiSpotViewController의 InfoScrollContentView의 높이값 옵션 Constraints를 수정했습니다.
```
// BbajiSpotViewController.swift
make.height.equalTo(UIDevice.current.hasNotch ? 508 : 508 - 32)
```
- 기종의 Notch 유무에 따라 높이 설정을 달리합니다.
- Minus 값이 32인 이유는, 물리 홈버튼을 가진 기종의 경우 뷰 Component들의 사이간격이 20px -> 16px로 변화하므로, InfoScrollContentView 내부의 Component들의 사이 간격을 (20-16) = 4를 8번 제거하기 위해 **32**라는 숫자가 나왔습니다.
- 자세한 사항은 Figma에서 BbajiSpotViewController Hifi 디자인을 참고

|iPhone 8+ 반영 전|iPhone 8+ 반영 후|
|:---:|:---:|
|![](https://user-images.githubusercontent.com/96641477/193855581-b47f573f-0cd9-453a-b903-6c9e0c3584f2.mov)|![](https://user-images.githubusercontent.com/96641477/193855666-7279cf1e-629e-4747-944d-e092a7cf4636.mov)|

## 이슈번호
#82 

Close #82