### PR TITLE
[2022/10/05] feat/BbajiHomeViewControllerConnectToBbajiSpotViewController >> BbajiHomeVC와 BbajiSpotVC 사이의 연결 구현

### DIFF
--- a/BJGG/BJGG/BbajiHome/BbajiHomeViewController.swift
+++ b/BJGG/BJGG/BbajiHome/BbajiHomeViewController.swift
@@ -17,6 +17,7 @@ final class BbajiHomeViewController: UIViewController {
         view.backgroundColor = .bbagaBack
         
         layoutConfigure()
+        delegateConfigure()
     }
 }
 
@@ -40,5 +41,15 @@ private extension BbajiHomeViewController {
             $0.trailing.equalToSuperview().inset(CGFloat.superViewInset)
             $0.bottom.equalToSuperview()
         }
+    }
+    
+    func delegateConfigure() {
+        bbajiListView.delegate = self
+    }
+}
+
+extension BbajiHomeViewController: BbajiListViewDelegate {
+    func pushBbajiSpotViewController() {
+        self.navigationController?.pushViewController(BbajiSpotViewController(), animated: true)
     }
 }

--- a/BJGG/BJGG/BbajiHome/UI Component/BbajiListView.swift
+++ b/BJGG/BJGG/BbajiHome/UI Component/BbajiListView.swift
@@ -7,7 +7,13 @@
 
 import UIKit
 
+protocol BbajiListViewDelegate {
+    func pushBbajiSpotViewController()
+}
+
 class BbajiListView: UIView {
+    var delegate: BbajiListViewDelegate?
+    
     private lazy var bbajiListCollectionView: BbajiListCollectionView = {
         let layout = UICollectionViewFlowLayout()
         let collectionView = BbajiListCollectionView(frame: .zero, collectionViewLayout: layout)
@@ -62,5 +68,10 @@ extension BbajiListView: UICollectionViewDataSource {
         return cell ?? UICollectionViewCell()
     }
     
-    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let idx = indexPath.row
+        if idx == 0 {
+            delegate?.pushBbajiSpotViewController()
+        }
+    }
 }


### PR DESCRIPTION
## 작업사항
- BbajiHomeViewController와 BbajiSpotViewController 사이의 연결을 구현했습니다.
- Protocol을 통해 delegate를 구현하여, UIView에서도 pushViewController를 호출할 수 있도록 만들었습니다.
```
// BbajiListView.swift

// Protocol 선언
protocol BbajiListViewDelegate {
    func pushBbajiSpotViewController()
}

class BbajiListView: UIView {
    var delegate: BbajiListViewDelegate?

    //Protocol 내부 메소드 호출
    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
        let idx = indexPath.row
        if idx == 0 {
            delegate?.pushBbajiSpotViewController()
        }
    }
}
```
```
// BbajiHomeViewController.swift

final class BbajiHomeViewController: UIViewController {
    bbajiListView.delegate = self // delegate 적용
}

//BbajiSpotViewController 호출하는 메소드 작성
extension BbajiHomeViewController: BbajiListViewDelegate {
    func pushBbajiSpotViewController() {
        self.navigationController?.pushViewController(BbajiSpotViewController(), animated: true)
    }
}
```

|반영 결과|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/193872349-909b75fb-48ac-4208-9ffd-86f8ce47adb6.mov)|

## 이슈번호
#84 

## 특이사항(Optional)
- BbajiHomeViewController -> BbajiSpotViewController로 이동하는 경우, 뷰가 자연스럽게 호출되지 않는 원인은 API 호출 후 DispatchQueue에 의해 UI가 갱신되는 문제로 추측됩니다. 해당 문제는 추후 Issue를 생성해 해결할 예정입니다.

Close #84 