### PR TITLE
[2022/10/05] feat/rainInfoTextMethod >> 현재날씨와 24시간 이후 날씨에 따른 기상정보 텍스트 반환 메소드 구현

### DIFF
--- a/BJGG/BJGG/Model/Weather.swift
+++ b/BJGG/BJGG/Model/Weather.swift
@@ -316,7 +316,7 @@ struct WeatherItems: Decodable {
                 if skyStatus == "맑음" {
                     return "\(day)은 계속 맑아요!"
                 } else {
-                    return "\(day)은 비소식이 없어요!!"
+                    return "\(day)은 비소식이 없어요!"
                 }
             }
             
@@ -353,7 +353,7 @@ struct WeatherItems: Decodable {
                     day = "오늘"
                 }
                 
-                return "\(day)은 계속\(status)\(postPosition) 와요!"
+                return "\(day)은 계속 \(status)\(postPosition) 와요!"
             }
         }
     }
@@ -373,9 +373,9 @@ struct WeatherItems: Decodable {
         }
         
         if weatherStatus == "강수없음" {
-            return (false, nil, skyStatus)
+            return (true, nil, skyStatus)
         } else {
-            return (true, weatherStatus, nil)
+            return (false, weatherStatus, nil)
         }
     }
     


### PR DESCRIPTION
## 작업사항
WeatherItem 데이터들의 강수상태, 하늘상태에 따른 RainInfo 텍스트 데이터를 제공하는 requestRainInfoText 메소드를 구현하였습니다.

## 이슈번호
- #53 

**[사용예시]**
<img width="560" alt="RainInfoExample" src="https://user-images.githubusercontent.com/83946704/193889935-8bf2338e-9021-4759-b99b-547b7ff5b2ed.png">


close #53 