### PR TITLE
[2022/10/05] fix/bbajiSpotViewControllerSpotWeatherInfoViewDataReviseUsingAPI >> SpotWeatherInfoView에서 사용되는 날씨 관련 Component 값들을 API로부터 받아오도록 수정

### DIFF
--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -85,7 +85,6 @@ final class BbajiSpotViewController: UIViewController {
     }
     
     private func configureLayoutWithAPI() {
-//        var timeNTempInfo: [(time: String, temperature: String)] = []
 
         let weatherManager = WeatherManager()
         weatherManager.request24hData(nx: 61, ny: 126) { success, response in
@@ -97,12 +96,6 @@ final class BbajiSpotViewController: UIViewController {
             let data = response.body.items.request24HourWeatherItem()
             let rainData = response.body.items.requestRainInfoText()
             let weatherDataTuple = response.body.items.requestWeatherDataSet(data)
-            
-//            for i in 0...data.count-1 {
-//                if data[i].category == "TMP" {
-//                    timeNTempInfo.append((time: data[i].timeValue, temperature: data[i].fcstValue))
-//                }
-//            }
             
             DispatchQueue.main.async { [self] in
                 spotWeatherInfoView = SpotWeatherInfoView(weatherInfo: weatherDataTuple)

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
@@ -14,7 +14,6 @@ final class SpotWeatherInfoView: UIView {
     
     var rainInfoLabel = UILabel()
     private var spotTodayWeatherCollectionView: SpotTodayWeatherCollectionView!
-    //private var currentTimeNTemperatureInfo: [(time: String, temperature: String)]!
     private var currentWeatherInfo: [(time: String, iconName: String, temp: String, probability: String)]!
     
     required init(weatherInfo: [(time: String, iconName: String, temp: String, probability: String)]) {


### PR DESCRIPTION
## 작업사항
- BbajiSpotViewController의 SpotWeatherInfoView 내부의 날씨 Compoent 전반을 기존에 구현된 날씨 API로부터 받아와 갱신하도록 변경했습니다.
- 위의 과정에서 필요없게된 이전 코드의 일부를 삭제했습니다.

|반영 결과|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/193937102-63327b17-a735-4e85-88fe-62a71183017f.mov)|

## 이슈번호
#94 

## 특이사항(Optional)
- API로부터 강수 관련 Sentence를 뽑아오는 메소드 테스트 결과, 강수 예정이 있을 때 현재 시각을 API 정보 그대로 추출하는 오류를 발견했습니다.

|예시 화면|
|:---:|
|<img width="300" alt="" src="https://user-images.githubusercontent.com/96641477/193936696-8a34e6ab-c603-438c-961e-3121955f24f5.png">|

Close #94