### PR TITLE
[2022/10/05] fix/requestRainInfoText >> WeatherItems 구조체의 requestRainInfoText 메소드가 시간 값을 내보낼 때 맵핑이 안되있는 오류 수정

### DIFF
--- a/BJGG/BJGG/Model/Weather.swift
+++ b/BJGG/BJGG/Model/Weather.swift
@@ -387,7 +387,9 @@ struct WeatherItems: Decodable {
                     day = "오늘"
                 }
                 
-                return "\(day) \(Int(time)!)시 경에 \(status)\(postPosition) 올 예정이에요!"
+                let timeValue = Int(time)! / 100
+                
+                return "\(day) \(timeValue)시 경에 \(status)\(postPosition) 올 예정이에요!"
             } else {
                 // 강수형태가 강수 없음에서 다른 형태로 바뀔 예정이 없을 경우
                 if isTimeLeftIn3hours(time) {
@@ -427,7 +429,9 @@ struct WeatherItems: Decodable {
                     day = "오늘"
                 }
                 
-                return "\(day) \(Int(time)!)시 경에 \(status)\(postPosition) 그칠 예정이에요!"
+                let timeValue = Int(time)! / 100
+                
+                return "\(day) \(timeValue)시 경에 \(status)\(postPosition) 그칠 예정이에요!"
             } else {
                 // 강수형태가 강수 없음으로 바뀔 예정이 없는 경우
                 if isTimeLeftIn3hours(time) {


### PR DESCRIPTION
## 작업사항
WeatherItems 구조체의 requestRainInfoText 메소드가 시간 값을 내보낼 때 맵핑이 안되있는 오류를 수정하였습니다.

## 이슈번호
- #98 

## 특이사항(Optional)
오전/오후 구분없이 24시 기준으로 내보내므로 View에서 사용하기 이전에 Controller에서 맵핑이 필요합니다.

(예시출력)
**prints >> 내일 22시 경에 비가 올 예정이에요!**

close #98 