### PR TITLE
[Design] design/addAccentColor >> 앱의 Accent Color를 추가

### DIFF
--- a/BJGG/BJGG/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/BJGG/BJGG/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,6 +1,15 @@
 {
   "colors" : [
     {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xBD",
+          "green" : "0xAC",
+          "red" : "0x00"
+        }
+      },
       "idiom" : "universal"
     }
   ],


### PR DESCRIPTION
## 작업사항
- 추후 뷰가 늘어날 경우에 대비하여 Navigation Item 단독 색상을 지정하는 것이 아닌, Accent Color를 설정하여 자동적으로 Navigation Bar Item의 색상으로 지정될 수 있도록 만들었습니다.

|반영 화면 (왼쪽 상단 주목)|
|:---:|
|<img width="300" alt="" src="https://user-images.githubusercontent.com/96641477/194106621-f9e24767-ed58-4f82-b5b2-a20753e83478.png">|

## 이슈번호
#102 

Close #102 