### PR TITLE
[Fix] fix/removeForceLandscapeFullScreenVideoOption >> SpotLiveCameraView FullScreen 시 강제 Landscape Option 제거

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
@@ -10,7 +10,7 @@ import AVKit
 
 final class SpotLiveCameraView: UIView {
     private var player: AVPlayer?
-    var avpController = RotatableAVPlayerViewController()
+    var avpController = AVPlayerViewController()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -30,19 +30,4 @@ final class SpotLiveCameraView: UIView {
         player?.play()
     }
 
-}
-
-class RotatableAVPlayerViewController: AVPlayerViewController {
-    
-    override var shouldAutorotate: Bool {
-        return false
-    }
-    
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-             return .landscapeRight
-          }
-    
-    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
-        return .landscapeRight
-    }
 }


### PR DESCRIPTION
## 작업사항
- BbajiSpotViewController의 AVPlayerViewController를 Subclassing을 제거하여 강제 Landscape 옵션을 삭제했습니다.
```
// SpotLiveViewCamera.swift에서 삭제된 코드부

class RotatableAVPlayerViewController: AVPlayerViewController {

    override var shouldAutorotate: Bool {
        return false
    }

    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
             return .landscapeRight
          }

    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
        return .landscapeRight
    }
}
```

|반영 결과|
|:---:|
|![](https://user-images.githubusercontent.com/96641477/194112003-5712df62-6168-4b2b-8571-6cdce126b837.mov)|

## 이슈번호
#104

## 특이사항(Optional)
- 추후 AVKit -> AVFoundation을 사용하여 Custom Video Player를 구현하는 형태로 변경될 가능성이 존재합니다.

Close #104 