### PR TITLE
[2022/10/06] fix/bbajiListCollectionViewIndicator >> BbajiListColletionView의 verticalScrollIndicator 안보이도록 구현

### DIFF
--- a/BJGG/BJGG/BbajiHome/UI Component/BbajiListView.swift
+++ b/BJGG/BJGG/BbajiHome/UI Component/BbajiListView.swift
@@ -27,6 +27,7 @@ class BbajiListView: UIView {
         collectionView.layer.cornerRadius = 10.0
         collectionView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         collectionView.layer.masksToBounds = true
+        collectionView.showsVerticalScrollIndicator = false
         
         return collectionView
     }()


### PR DESCRIPTION
## 작업사항
BbajiListColletionView의 verticalScrollIndicator가 안보이도록 구현하였습니다.

## 이슈번호
- #112 

close #112 