### PR TITLE
[2022/10/06] fix/weatherManagerCompletionHandler >> WeatherManager에서 API 호출 실패시에 전달할 completionHandler 로직 구현

### DIFF
--- a/BJGG/BJGG/Model/WeatherManager.swift
+++ b/BJGG/BJGG/Model/WeatherManager.swift
@@ -79,6 +79,7 @@ struct WeatherManager {
         
         guard let url = URL(string: url) else {
             print("Error: cannet create URL")
+            completionHandler(false, [])
             return
         }
         
@@ -88,22 +89,26 @@ struct WeatherManager {
         URLSession.shared.dataTask(with: request) { data, response, error in
             guard error == nil else {
                 print("Error: error calling GET")
+                completionHandler(false, [])
                 print(error!)
                 return
             }
             
             guard let data = data else {
                 print("Error: Did not receive data")
+                completionHandler(false, [])
                 return
             }
             
             guard let response = response as? HTTPURLResponse, (200..<300) ~= response.statusCode else {
                 print("Error: HTTP request failed")
+                completionHandler(false, [])
                 return
             }
             
             guard let output = try? JSONDecoder().decode(Weather.self, from: data) else {
                 print("Error: JSON data Parsing failed")
+                completionHandler(false, [])
                 return
             }
             


### PR DESCRIPTION
## 작업사항
WeatherManager에서 API 호출 실패시에 completionHandler에서 false와 빈 배열을 반환하도록 로직을 수정하였습니다.

## 이슈번호
- #101 

## 참고사항
아래의 상황에서 이제 API 호출에 실패할 경우, success는 **false**를, response는 [ ]를 반환하게 됩니다.
<img width="774" alt="스크린샷 2022-10-06 오전 5 25 35" src="https://user-images.githubusercontent.com/83946704/194156532-5b58c6a6-ae7c-4b20-8e76-518c7947bed5.png">

close #101 
