### PR TITLE
[2022/10/06] fix/bbajiHomeViewControllerDarkMode >> BbajiHomeViewController 다크모드 대응

### DIFF
--- a/BJGG/BJGG/BbajiHome/UI Component/BbajiListView.swift
+++ b/BJGG/BJGG/BbajiHome/UI Component/BbajiListView.swift
@@ -30,6 +30,8 @@ class BbajiListView: UIView {
         collectionView.layer.masksToBounds = true
         collectionView.showsVerticalScrollIndicator = false
         
+        collectionView.backgroundColor = .bbagaGray4
+        
         return collectionView
     }()
     


### PR DESCRIPTION
## 작업사항
BbajiHomeViewController의 다크모드 대응을 위해 BbajiListCollectionView의 backgroundColor를 bbajiGray4로 설정하였습니다.

|다크모드 대응 전|다크모드 대응 후|
|:---:|:---:|
|<img width="340" alt="스크린샷 2022-10-06 오전 12 35 57" src="https://user-images.githubusercontent.com/83946704/194157662-9f29b02b-3885-4141-a4cf-a6c3316beb2d.png">|<img width="340" alt="스크린샷 2022-10-06 오전 12 35 57" src="https://user-images.githubusercontent.com/83946704/194159378-380ea5e7-73da-417a-8e2a-390d2dbffd7c.png">|


## 이슈번호
- #119 

## 특이사항(Optional)
BbajiListCollectionView의 배경부분이 BbajiHomeViewController 배경이미지의 흰색 부분과 겹쳐서 다음과 같이 구현하였습니다. 이후에 BbajiHomeViewController의 배경이미지가 변경이 되거나 BbajiHomeViewController의 배경이미지와 겹치는 부분이 달라질 경우 구현방법이 변경될 여지가 있습니다.

close #119 