### PR TITLE
배포용 버전 1.0.1

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotTodayWeatherCollectionViewCell.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotTodayWeatherCollectionViewCell.swift
@@ -30,28 +30,27 @@ final class SpotTodayWeatherCollectionViewCell: UICollectionViewCell {
         self.addSubview(currentRainPercentLabel)
         self.addSubview(currentWeatherImgView)
         if isRain {
-            currentRainPercentLabel.snp.makeConstraints({ make in
+            currentRainPercentLabel.snp.remakeConstraints({ make in
                 make.top.equalTo(self.snp.top)
                 make.centerX.equalTo(self.snp.centerX)
                 make.width.equalTo(48)
                 make.height.equalTo(19)
             })
-            currentWeatherImgView.snp.makeConstraints({ make in
+            currentWeatherImgView.snp.remakeConstraints({ make in
                 make.top.equalTo(currentRainPercentLabel.snp.bottom)
                 make.centerX.equalTo(self.snp.centerX)
                 make.width.height.equalTo(28)
             })
         } else {
-            currentWeatherImgView.snp.makeConstraints({ make in
+            currentWeatherImgView.snp.remakeConstraints({ make in
                 make.top.equalTo(self.snp.top)
-                make.leading.equalTo(self.snp.leading)
                 make.centerX.equalTo(self.snp.centerX)
                 make.width.height.equalTo(48)
             })
         }
         
         self.addSubview(temperatureLabel)
-        temperatureLabel.snp.makeConstraints({ make in
+        temperatureLabel.snp.remakeConstraints({ make in
             make.top.equalTo(currentWeatherImgView.snp.bottom).offset(CGFloat.iconOffset)
             make.centerX.equalTo(currentWeatherImgView.snp.centerX)
             make.height.equalTo(22)
@@ -59,7 +58,7 @@ final class SpotTodayWeatherCollectionViewCell: UICollectionViewCell {
         })
         
         self.addSubview(timeLabel)
-        timeLabel.snp.makeConstraints({ make in
+        timeLabel.snp.remakeConstraints({ make in
             make.top.equalTo(temperatureLabel.snp.bottom).offset(2)
             make.centerX.equalTo(temperatureLabel.snp.centerX)
             make.height.equalTo(18)

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
@@ -205,8 +205,9 @@ extension SpotWeatherInfoView: UICollectionViewDelegate, UICollectionViewDataSou
             timeStr = "--"
         }
         
-        if currentRainPercentStr == "0" {
+        if currentRainPercentStr == "0%" {
             cell.layoutConfigure(isRain: false)
+            cell.currentRainPercentLabel.text = ""
         } else {
             cell.layoutConfigure(isRain: true)
             labelSetting(label: cell.currentRainPercentLabel, text: currentRainPercentStr, font: .bbajiFont(.rainyCaption), alignment: .center)


### PR DESCRIPTION
## 작업사항
- Issue #138 PR #139
-> BbajiSpotViewController의 SpotTodayWeatherCollectionViewCell이 강수 확률 Label과 관련하여 수정했습니다

|App Store Connect 관련 요소 |배포 1.0.1 반영 필요 사항|
|:---|:---:|
|**iOS 미리보기 및 스크린샷**|밤사진 -> 낮사진으로 대체합니다.|
|**프로모션 텍스트**|1.0과 동일하게 유지합니다.|
|**수정 사항**| - 오류 수정: 강수 확률 0%인 경우에도 강수량이 출력되는 오류 수정|

**2022.10.07일자 PM09:46기준, `프로모션 텍스트`와 `수정 사항`은 반영되었습니다.**