### PR TITLE
[2022/10/08] fix/reviseApplicationDefaultLanguage >> 앱 기본 언어 한국어로 변경

### DIFF
--- a/BJGG/BJGG.xcodeproj/project.pbxproj
+++ b/BJGG/BJGG.xcodeproj/project.pbxproj
@@ -295,10 +295,10 @@
 			};
 			buildConfigurationList = 55CB0A9F28BA4F9F0045644C /* Build configuration list for PBXProject "BJGG" */;
 			compatibilityVersion = "Xcode 13.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
+				ko,
 				Base,
 			);
 			mainGroup = 55CB0A9B28BA4F9F0045644C;


### PR DESCRIPTION
## 작업사항
- 앱의 기본 언어를 한국어로 변경했습니다.

### 토막 상식
|앱의 기본 언어를 변경하는 방법|
|:---|
|1. .pbxproj 파일로 들어갑니다|
|2. `developmentRegion`를 변경합니다|
|3. `knownRegions`을 변경합니다|

**변경 전 코드**
```
// .pbxproj

developmentRegion = en;
hasScannedForEncodings = 0;
knownRegions = (
	en,
	Base,
);
```
**변경 후 코드**
```
// .pbxproj

developmentRegion = ko;
hasScannedForEncodings = 0;
knownRegions = (
	ko,
	Base,
);
```

## 이슈번호
#141

Close #141