### PR TITLE
배포용 1.0.2

### DIFF
--- a/BJGG/BJGG.xcodeproj/project.pbxproj
+++ b/BJGG/BJGG.xcodeproj/project.pbxproj
@@ -295,10 +295,10 @@
 			};
 			buildConfigurationList = 55CB0A9F28BA4F9F0045644C /* Build configuration list for PBXProject "BJGG" */;
 			compatibilityVersion = "Xcode 13.0";
-			developmentRegion = en;
+			developmentRegion = ko;
 			hasScannedForEncodings = 0;
 			knownRegions = (
-				en,
+				ko,
 				Base,
 			);
 			mainGroup = 55CB0A9B28BA4F9F0045644C;


### PR DESCRIPTION
## 작업사항
- Issue #141 PR #142
-> 앱 기본 언어 설정을 `영어`에서 `한국어`로 변경했습니다.

|App Store Connect 관련 요소 |배포 1.0.2 반영 필요 사항|
|:---|:---:|
|**프로모션 텍스트**|1.0과 동일하게 유지합니다.|
|**수정 사항**| - 오류 수정: 앱 기본 언어 설정을 영어에서 한국어로 변경했습니다.|

**2022.10.09일자 AM12:50기준, `프로모션 텍스트`와 `수정 사항`은 반영되었습니다.**