### PR TITLE
배포용 버전 1.0.3

### DIFF
--- a/BJGG/BJGG/Model/WeatherManager.swift
+++ b/BJGG/BJGG/Model/WeatherManager.swift
@@ -23,9 +23,6 @@ struct WeatherManager {
         case 0..<300:
             let day = str.split(separator: " ").map{ Int($0)! }[0]
             return String(day-1)
-        case 2300...2400:
-            let day = str.split(separator: " ").map{ Int($0)! }[0]
-            return String(day-1)
             
         default:
             return str.split(separator: " ").map{ String($0) }[0]


### PR DESCRIPTION
## 작업사항
- Issue #144 PR #145 
-> 오후 11시부터 한시간동안 BbajiSpotViewController에 들어갈 때 앱이 꺼지는 에러를 WeatherManager의 수정을 통해 해결하였습니다.

|App Store Connect 관련 요소 |배포 1.0.3 반영 필요 사항|
|:---|:---:|
|**iOS 미리보기 및 스크린샷**|밤사진 -> 낮사진으로 대체합니다.|
|**프로모션 텍스트**|1.0과 동일하게 유지합니다.|
|**수정 사항**| - 오류 수정: 오후 11시부터 한시간동안 BbajiSpotViewController 에 들어가면 앱이 꺼지는 오류 수정|
