### PR TITLE
[2023/02/03]  fix/CUICatalogErrorMessage >> [framework] CUICatalog: Invalid asset name supplied: '' 에러메세지 수정

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherInfoView.swift
@@ -214,7 +214,9 @@ extension SpotWeatherInfoView: UICollectionViewDelegate, UICollectionViewDataSou
             cell.currentRainPercentLabel.textColor = .bbagaRain
         }
         
-        cell.currentWeatherImgView.image = UIImage(named: currentWeatherImgName)
+        if currentWeatherImgName != "" {
+            cell.currentWeatherImgView.image = UIImage(named: currentWeatherImgName)
+        }
         
         labelSetting(label: cell.temperatureLabel, text: temperatureStr, font: .bbajiFont(.heading5), alignment: .center)
         labelSetting(label: cell.timeLabel, text: timeStr, font: .bbajiFont(.body1), alignment: .center)


### PR DESCRIPTION
## 작업사항
BbajiSpotViewController에 진입했을 때 나타나던 `[framework] CUICatalog: Invalid asset name supplied: ''` 메세지가 나타나지 않도록 수정하였습니다.

|확인 이미지|
|:---:|
|<img width="846" alt="스크린샷 2023-02-03 오전 11 42 03" src="https://user-images.githubusercontent.com/83946704/216499870-ec5bf13a-f9fa-4d24-b755-46084dfd9bc2.png">|

## 이슈번호
- #148 

close #148 
