### PR TITLE
[2023/02/15] refactor/weatherAPIKeyAccessMethod >> WeatherManager 날씨 API 접근 방식 수정

### DIFF
--- a/BJGG/BJGG/Model/WeatherManager.swift
+++ b/BJGG/BJGG/Model/WeatherManager.swift
@@ -66,7 +66,16 @@ struct WeatherManager {
     }()
     
     private func requestWeather(nx: Int, ny: Int, numberOfRow: Int) async throws -> Weather {
-        let urlString = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=\(APIKey.key)&numOfRows=\(numberOfRow)&pageNo=1&dataType=JSON&base_date=\(today)&base_time=\(nowTime)&nx=\(nx)&ny=\(ny)"
+        guard let privatePlist = Bundle.main.url(forResource: "Private", withExtension: "plist") else {
+            throw WeatherManagerError.urlError
+        }
+        
+        guard let dictionary = NSDictionary(contentsOf: privatePlist) else {
+            throw WeatherManagerError.urlError
+        }
+        
+        let weatherAPIKey = dictionary["weatherAPIKey"] as! String
+        let urlString = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=\(weatherAPIKey)&numOfRows=\(numberOfRow)&pageNo=1&dataType=JSON&base_date=\(today)&base_time=\(nowTime)&nx=\(nx)&ny=\(ny)"
         
         guard let url = URL(string: urlString) else {
             throw WeatherManagerError.urlError


### PR DESCRIPTION
## 작업사항
날씨 API Key 접근 방식이 수정됨에 따라 `WeatherManager`에서의 API Key 접근 방식을 수정했습니다.

**해당 PR에서 수정된 코드를 적용하기 위해선 먼저 `Private.plist`의 날씨 API Key 값 추가가 필요합니다.**
|기존 형태|바뀐 형태|
|:---:|:---:|
|날씨 API Key 구조체를 통해 API 접근 관리|`.plist`를 통해 API Key 접근 관리|

-> 따라서 아래와 같은 형태로 APIKey에 접근합니다.
```swift
guard let privatePlist = Bundle.main.url(forResource: "Private", withExtension: "plist") else {
    throw WeatherManagerError.urlError
}
guard let dictionary = NSDictionary(contentsOf: privatePlist) else {
    throw WeatherManagerError.urlError
 }
        
let weatherAPIKey = dictionary["weatherAPIKey"] as! String
let urlString = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=\(weatherAPIKey)&numOfRows=\(numberOfRow)&pageNo=1&dataType=JSON&base_date=\(today)&base_time=\(nowTime)&nx=\(nx)&ny=\(ny)"

guard let url = URL(string: urlString) else {
    throw WeatherManagerError.urlError
}
```

## 이슈번호
- #152 

## 특이사항(Optional)
1. 날씨 API 호출이 있을 때에만 plist에 접근하여 Key를 받아오는 형태로 구현했기에, 기존 코드와 동일하게 메소드 `requestWeather(nx: Int, ny: Int, numberOfRow: Int)` 내부에서 APIKey를 호출합니다.
2. `plist` 접근에 실패하거나, dictionary로 치환에 실패한 경우에 해당하는 Error throw를 임시로 `WeatherManagerError.urlError`로 두었습니다. 추후 `plist` 접근과 관련된 Error Handling enum 작성이 이루어질 필요가 있다고 판단됩니다.
```swift
guard let privatePlist = Bundle.main.url(forResource: "Private", withExtension: "plist") else {
    throw WeatherManagerError.urlError // << !HERE!
}
guard let dictionary = NSDictionary(contentsOf: privatePlist) else {
    throw WeatherManagerError.urlError // << !HERE!
 }
```

Close #152 