### PR TITLE
[2023/02/22] refactor/removeEnumAPIStatus >> 사용되지 않는 Enum APIStatus 제거

### DIFF
--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherAPIInfoView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotWeatherAPIInfoView.swift
@@ -7,11 +7,6 @@
 
 import UIKit
 
-// API Test Enum
-enum APIStatus {
-    case success, loading, failure
-}
-
 final class SpotWeatherAPIInfoView: UIView {
     private let currentAPIInfoLabel = UILabel()
     private let currentAPIInfoLabelDeco = UIImageView()


### PR DESCRIPTION
## 작업사항
프로젝트 초기 작업 시, 날씨 관련 API 테스트를 위해 임시로 작성했던 enum `APIStatus`를 삭제

## 이슈번호
- #158

Close #158 