### PR TITLE
[2023/02/22] refactor/hasNotchComputedProperty >> Computed Property hasNotch의 iOS 버전별 대응 코드부 제거

### DIFF
--- a/BJGG/BJGG/Extension/UIDevice+DeviceCheck.swift
+++ b/BJGG/BJGG/Extension/UIDevice+DeviceCheck.swift
@@ -10,12 +10,10 @@ import UIKit
 // https://developer.apple.com/forums/thread/709997
 extension UIDevice {
     var hasNotch: Bool {
-        if #available(iOS 13.0, *) {
-            let scenes = UIApplication.shared.connectedScenes
-            let windowScene = scenes.first as? UIWindowScene
-            guard let window = windowScene?.windows.first else { return false }
-            
-            return window.safeAreaInsets.top > 20
-        }
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first as? UIWindowScene
+        guard let window = windowScene?.windows.first else { return false }
+        
+        return window.safeAreaInsets.top > 20
     }
 }


### PR DESCRIPTION
## 작업사항

|`hasNotch`|
|:---|
|기종별 대응을 위해 작성했던 Computed property|

**1. `hasNotch`의 iOS11 버전으로 분기처리하여 다루던 코드를 삭제**
- 현재 앱의 Deployment Target이 `15.5`부터이기 때문에 iOS11버전과 관련된 코드부는 사용되지 않아 삭제했습니다.
```swift
// UIDevice+DeviceCheck.swift 삭제된 코드부 (line.21-27)
        if #available(iOS 11.0, *) {
            let top = UIApplication.shared.windows[0].safeAreaInsets.top
            return top > 20
        } else {
            // Fallback on earlier versions
            return false
        }
```
**2. 1과 동일하게 Deployment Target이 15.5부터 시작하기 때문에 iOS13 이상인지를 판별하는 if문도 필요하지 않아 삭제했습니다.**
- 기존 코드: iOS13버전 이상인지 판별
```swift
// UIDevice+DeviceCheck.swift line.13-19
 if #available(iOS 13.0, *) {
            let scenes = UIApplication.shared.connectedScenes
            let windowScene = scenes.first as? UIWindowScene
            guard let window = windowScene?.windows.first else { return false }
            
            return window.safeAreaInsets.top > 20
        }
```
- 바뀐 코드: if문을 거치지 않고 즉시 기종 판별
```swift
// UIDevice+DeviceCheck.swift
        let scenes = UIApplication.shared.connectedScenes
        let windowScene = scenes.first as? UIWindowScene
        guard let window = windowScene?.windows.first else { return false }
        
        return window.safeAreaInsets.top > 20
```
## 이슈번호
- #162 

## 특이사항(Optional)
- 유저가 기존에 iOS 15.5 버전 이상을 사용하다가 모종의 이유로 Downgrade를 진행해서 iOS11로 만드는 것과 같은 Edge Case에 대해선 어떤 처리가 이루어지는지를 관측할 필요가 있다고 생각합니다.

Close #162