### PR TITLE
[2023/03/08] refactor/bbajiConstraints >> BbajiConstraint에 private init 설정

### DIFF
--- a/BJGG/BJGG/Utilities/Constraints.swift
+++ b/BJGG/BJGG/Utilities/Constraints.swift
@@ -5,10 +5,9 @@
 //  Created by 이재웅 on 2023/02/22.
 //
 
-import Foundation
 import UIKit
 
-struct BbajiConstraints {
+final class BbajiConstraints {
     // label 간 간격 constraint
     static let labelOffset: CGFloat = 4.0
     

--- a/BJGG/BJGG/Utilities/Constraints.swift
+++ b/BJGG/BJGG/Utilities/Constraints.swift
@@ -23,4 +23,6 @@ struct BbajiConstraints {
     
     // view와 내부 component 간 간격 constraint
     static let viewInset: CGFloat = UIDevice.current.hasNotch ? 20.0 : 16.0
+    
+    private init() { }
 }


### PR DESCRIPTION
## 작업사항
BbajiConstraint 구조체의 불필요한 초기화를 방지하기 위해 `private init() { }` 코드를 추가하였습니다.

## 이슈번호
- #171 

## 특이사항(Optional)
struct 타입이 enum 타입보다 BbajiConstraints 사용 의도를 확인하는데 더욱 효과적이라 판단해 타입을 변경하지 않았습니다.

close #171 