### PR TITLE
[2022/03/09] refactor/weatherManagerErrorCase >> WeatherManagerError의 case명 수정

### DIFF
--- a/BJGG/BJGG/BbajiHome/BbajiHomeViewController.swift
+++ b/BJGG/BJGG/BbajiHome/BbajiHomeViewController.swift
@@ -146,11 +146,9 @@ extension BbajiHomeViewController {
                     
                     self.weatherData = weatherData
                 }
-            } catch WeatherManagerError.urlError(let message) {
-                print(message)
             } catch WeatherManagerError.apiError(let message) {
                 print(message)
-            } catch WeatherManagerError.clientError(let message) {
+            } catch WeatherManagerError.networkError(let message) {
                 print(message)
             } catch DecodingError.dataCorrupted(let description) {
                 print(description.codingPath, description.debugDescription, description.underlyingError ?? "", separator: "\n")

--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -144,9 +144,7 @@ final class BbajiSpotViewController: UIViewController {
                 
                 if let weatherManagerError = error as? WeatherManagerError {
                     switch weatherManagerError {
-                    case .urlError(let message):
-                        print(message)
-                    case .clientError(let message):
+                    case .networkError(let message):
                         print(message)
                     case .apiError(let message):
                         print(message)

--- a/BJGG/BJGG/Network/WeatherManager.swift
+++ b/BJGG/BJGG/Network/WeatherManager.swift
@@ -8,8 +8,7 @@
 import Foundation
 
 enum WeatherManagerError: Error {
-    case urlError(String)
-    case clientError(String)
+    case networkError(String)
     case apiError(String)
 }
 

--- a/BJGG/BJGG/Network/WeatherManager.swift
+++ b/BJGG/BJGG/Network/WeatherManager.swift
@@ -86,21 +86,15 @@ struct WeatherManager {
         let (data, httpResponse) = try await URLSession.shared.data(for: request)
         
         guard let httpURLResponse = httpResponse as? HTTPURLResponse else {
-            throw WeatherManagerError.apiError("WeatherManager Error : HTTP URL 요청 실패")
+            throw WeatherManagerError.networkError("WeatherManager Network Error : HTTP URL 응답 실패")
         }
         
         switch httpURLResponse.statusCode {
         case 200..<300:
             let weatherData = try JSONDecoder().decode(Weather.self, from: data)
             return weatherData
-        case 100..<200:
-            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 100")
-        case 300..<400:
-            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 300")
-        case 400..<500:
-            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 400")
         default:
-            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 500")
+            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code \(httpURLResponse.statusCode)")
         }
     }
     

--- a/BJGG/BJGG/Network/WeatherManager.swift
+++ b/BJGG/BJGG/Network/WeatherManager.swift
@@ -91,13 +91,17 @@ struct WeatherManager {
         }
         
         switch httpURLResponse.statusCode {
-        case (200..<300):
+        case 200..<300:
             let weatherData = try JSONDecoder().decode(Weather.self, from: data)
             return weatherData
-        case (300..<500):
-            throw WeatherManagerError.clientError("WeatherManager Error : 네트워크 응답 실패")
+        case 100..<200:
+            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 100")
+        case 300..<400:
+            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 300")
+        case 400..<500:
+            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 400")
         default:
-            throw WeatherManagerError.apiError("WeatherManager Error : 기상청 API 요청 실패")
+            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code 500")
         }
     }
     


### PR DESCRIPTION
## 작업사항
1. WeatherManagerError의 case명을 수정하였습니다.
(1) urlError 제거 : urlError는 WeatherManager 내부에서 PlistError를 통해 반환되는 에러로 변경되어 사용되지 않아 제거하였습니다.
(2) clientError에서 networkError로 변경 : clientError의 용도가 불명확하고 apiError와 networkError로 구분하는 것이 명시적으로 구분된다 판단하여 수정하였습니다.

```swift
// 수정 전
enum WeatherManagerError: Error {
    case urlError(String)
    case clientError(String)
    case apiError(String)
}
```

```swift
// 수정 후
enum WeatherManagerError: Error {
    case networkError(String)
    case apiError(String)
}
```

2. WeatherManager 에러전달 메세지 수정
(1) networkError 발생시의 에러전달 메세지를 수정하였습니다.
(2) apiError 발생시 각 응답상태코드를 나타내도록 수정하였습니다.

```swift
// networkError 발생시
guard let httpURLResponse = httpResponse as? HTTPURLResponse else {
            throw WeatherManagerError.networkError("WeatherManager Network Error : HTTP URL 응답 실패")
        }
```

```swift
// apiError 발생시
switch httpURLResponse.statusCode {
        case 200..<300:
            let weatherData = try JSONDecoder().decode(Weather.self, from: data)
            return weatherData
        default:
            throw WeatherManagerError.apiError("WeatherManager API Error : Statue Code \(httpURLResponse.statusCode)")
        }
```


## 이슈번호
- #170 

## 특이사항(Optional)
1. 네트워크 에러에 관련해 논의가 필요하거나 부족한 부분이 있을 시 언제든 코멘트 달아주시길 바랍니다. :)

2. 현재 에러 발생시 print문으로 처리를 하고 있습니다. 이미 앱이 서비스가 되고있고 가까운 업데이트에 기능이 더욱 추가될 예정이므로 에러 발생 시에 Alert를 통해 에러상황을 안내하고 문의 가능한 연락처를 제공하는 방식으로 처리해야할 필요성이 보입니다. 이와 같은 내용은 Issue발행과 회의를 통해 논의를 할 수 있도록 하겠습니다.

close #170 