### PR TITLE
[2023/03/14] refactor/dateVariables >> Weather, WeatherManager 내부 날짜/시간 변수로직 리팩토링

### DIFF
--- a/BJGG/BJGG.xcodeproj/project.pbxproj
+++ b/BJGG/BJGG.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		55CB0AB428BA4FA10045644C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 55CB0AB228BA4FA10045644C /* LaunchScreen.storyboard */; };
 		55CB0ABC28BB41C60045644C /* BbajiHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CB0ABB28BB41C60045644C /* BbajiHomeViewController.swift */; };
 		55F0AE6129BF5DE4003B5EEE /* Date+Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F0AE6029BF5DE4003B5EEE /* Date+Weather.swift */; };
+		55F0AE6529C04C50003B5EEE /* WeatherTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F0AE6429C04C50003B5EEE /* WeatherTime.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -111,6 +112,7 @@
 		55CB0AB528BA4FA10045644C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55CB0ABB28BB41C60045644C /* BbajiHomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BbajiHomeViewController.swift; sourceTree = "<group>"; };
 		55F0AE6029BF5DE4003B5EEE /* Date+Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Weather.swift"; sourceTree = "<group>"; };
+		55F0AE6429C04C50003B5EEE /* WeatherTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherTime.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,6 +132,7 @@
 			children = (
 				3A7E3BDE28D748B000F6416A /* BbajiInfo.swift */,
 				553F0FA628E9E11E00FD9CDA /* Weather.swift */,
+				55F0AE6429C04C50003B5EEE /* WeatherTime.swift */,
 				3AA6369F29A65F3F006BB5EF /* PlistError.swift */,
 			);
 			path = Model;
@@ -401,6 +404,7 @@
 				3AA636A029A65F3F006BB5EF /* PlistError.swift in Sources */,
 				3A5E18F328E4570000CBEDE3 /* UILabel+CopyLabelText.swift in Sources */,
 				3A5E18F528E8A8A000CBEDE3 /* UIDevice+DeviceCheck.swift in Sources */,
+				55F0AE6529C04C50003B5EEE /* WeatherTime.swift in Sources */,
 				3A7E3BE728D766EC00F6416A /* SpotWeatherInfoView.swift in Sources */,
 				553F0F9D28E4AD7500FD9CDA /* BbajiListCollectionView.swift in Sources */,
 				553F0FA928E9E80D00FD9CDA /* WeatherManager.swift in Sources */,

--- a/BJGG/BJGG.xcodeproj/project.pbxproj
+++ b/BJGG/BJGG.xcodeproj/project.pbxproj
@@ -19,12 +19,12 @@
 		3A7E3BE528D766D700F6416A /* SpotLiveCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7E3BE428D766D700F6416A /* SpotLiveCameraView.swift */; };
 		3A7E3BE728D766EC00F6416A /* SpotWeatherInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7E3BE628D766EC00F6416A /* SpotWeatherInfoView.swift */; };
 		3A7E3BE928D7670000F6416A /* SpotInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7E3BE828D7670000F6416A /* SpotInfoView.swift */; };
+		3AA636A029A65F3F006BB5EF /* PlistError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA6369F29A65F3F006BB5EF /* PlistError.swift */; };
 		3AA636E129B390B6006BB5EF /* SpotLiveCameraControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E029B390B6006BB5EF /* SpotLiveCameraControlView.swift */; };
 		3AA636E329B390EE006BB5EF /* ScreenSizeControlButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E229B390EE006BB5EF /* ScreenSizeControlButton.swift */; };
 		3AA636E529B391FF006BB5EF /* LiveMarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E429B391FF006BB5EF /* LiveMarkView.swift */; };
 		3AA636E729B4C8CA006BB5EF /* SpotLiveCameraGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E629B4C8CA006BB5EF /* SpotLiveCameraGradientView.swift */; };
 		3AA636E929B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift */; };
-		3AA636A029A65F3F006BB5EF /* PlistError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA6369F29A65F3F006BB5EF /* PlistError.swift */; };
 		3AD87FB228D892D300ABD2E4 /* IconAndLabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD87FB128D892D300ABD2E4 /* IconAndLabelView.swift */; };
 		42600D5928EF200B00D114BC /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 42600D5828EF200B00D114BC /* Private.plist */; };
 		42600D5F28EF322500D114BC /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 42600D5E28EF322500D114BC /* Settings.bundle */; };
@@ -56,6 +56,7 @@
 		55CB0AB128BA4FA10045644C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 55CB0AB028BA4FA10045644C /* Assets.xcassets */; };
 		55CB0AB428BA4FA10045644C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 55CB0AB228BA4FA10045644C /* LaunchScreen.storyboard */; };
 		55CB0ABC28BB41C60045644C /* BbajiHomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CB0ABB28BB41C60045644C /* BbajiHomeViewController.swift */; };
+		55F0AE6129BF5DE4003B5EEE /* Date+Weather.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F0AE6029BF5DE4003B5EEE /* Date+Weather.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,12 +71,12 @@
 		3A7E3BE428D766D700F6416A /* SpotLiveCameraView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotLiveCameraView.swift; sourceTree = "<group>"; };
 		3A7E3BE628D766EC00F6416A /* SpotWeatherInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotWeatherInfoView.swift; sourceTree = "<group>"; };
 		3A7E3BE828D7670000F6416A /* SpotInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotInfoView.swift; sourceTree = "<group>"; };
+		3AA6369F29A65F3F006BB5EF /* PlistError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistError.swift; sourceTree = "<group>"; };
 		3AA636E029B390B6006BB5EF /* SpotLiveCameraControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotLiveCameraControlView.swift; sourceTree = "<group>"; };
 		3AA636E229B390EE006BB5EF /* ScreenSizeControlButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSizeControlButton.swift; sourceTree = "<group>"; };
 		3AA636E429B391FF006BB5EF /* LiveMarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMarkView.swift; sourceTree = "<group>"; };
 		3AA636E629B4C8CA006BB5EF /* SpotLiveCameraGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotLiveCameraGradientView.swift; sourceTree = "<group>"; };
 		3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotLiveCameraStanbyView.swift; sourceTree = "<group>"; };
-		3AA6369F29A65F3F006BB5EF /* PlistError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlistError.swift; sourceTree = "<group>"; };
 		3AD87FB128D892D300ABD2E4 /* IconAndLabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconAndLabelView.swift; sourceTree = "<group>"; };
 		42600D5828EF200B00D114BC /* Private.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Private.plist; sourceTree = "<group>"; };
 		42600D5E28EF322500D114BC /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -109,6 +110,7 @@
 		55CB0AB328BA4FA10045644C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		55CB0AB528BA4FA10045644C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		55CB0ABB28BB41C60045644C /* BbajiHomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BbajiHomeViewController.swift; sourceTree = "<group>"; };
+		55F0AE6029BF5DE4003B5EEE /* Date+Weather.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Weather.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -225,6 +227,7 @@
 				553F0F8128E2100000FD9CDA /* UIFont+CustomFont.swift */,
 				3A5E18F228E4570000CBEDE3 /* UILabel+CopyLabelText.swift */,
 				3A5E18F428E8A89F00CBEDE3 /* UIDevice+DeviceCheck.swift */,
+				55F0AE6029BF5DE4003B5EEE /* Date+Weather.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -380,6 +383,7 @@
 				3A7E3BE328D7663300F6416A /* BbajiSpotViewController.swift in Sources */,
 				3AA636E929B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift in Sources */,
 				553F0FA128E4C58600FD9CDA /* ShadowGradientView.swift in Sources */,
+				55F0AE6129BF5DE4003B5EEE /* Date+Weather.swift in Sources */,
 				55CB0ABC28BB41C60045644C /* BbajiHomeViewController.swift in Sources */,
 				553F0FA328E4D5AA00FD9CDA /* PreviewView.swift in Sources */,
 				3AA636E529B391FF006BB5EF /* LiveMarkView.swift in Sources */,

--- a/BJGG/BJGG/Extension/Date+Weather.swift
+++ b/BJGG/BJGG/Extension/Date+Weather.swift
@@ -1,0 +1,22 @@
+//
+//  Date+Weather.swift
+//  BJGG
+//
+//  Created by 이재웅 on 2023/03/13.
+//
+
+import Foundation
+
+extension Date {
+    /// 현재시간을 String 타입의 yyyyMMdd HHmm 형식으로 반환하는 변수
+    static var currentStringForWeather: String {
+        let now = Date()
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd HHmm"
+        formatter.locale = Locale(identifier: "ko_kr")
+        formatter.timeZone = TimeZone(abbreviation: "KST")
+        
+        return formatter.string(from: now)
+    }
+    
+}

--- a/BJGG/BJGG/Extension/Date+Weather.swift
+++ b/BJGG/BJGG/Extension/Date+Weather.swift
@@ -8,15 +8,22 @@
 import Foundation
 
 extension Date {
-    /// 현재시간을 String 타입의 yyyyMMdd HHmm 형식으로 반환하는 변수
-    static var currentStringForWeather: String {
+    /// 현재시간을 WeatherTime으로 반환하는 변수
+    static var currentWeatherTime: WeatherTime {
         let now = Date()
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyyMMdd HHmm"
         formatter.locale = Locale(identifier: "ko_kr")
         formatter.timeZone = TimeZone(abbreviation: "KST")
+        let date = formatter.string(from: now).split(separator: " ")
         
-        return formatter.string(from: now)
+        guard let days = Int(date[0]), let time = Int(date[1]) else {
+            print("Date currenyWeatherTime Error : 현재시간의 형식반환에서 오류가 발생했습니다.")
+            print("에러발생 Date() : \(date)")
+            print("현재 반환된 currentWeatherTime: (20230101, 0000)")
+            return WeatherTime(20230101, 0000)
+        }
+        
+        return WeatherTime(days, time)
     }
-    
 }

--- a/BJGG/BJGG/Model/Weather.swift
+++ b/BJGG/BJGG/Model/Weather.swift
@@ -204,7 +204,6 @@ struct WeatherItem: Decodable {
 
 struct WeatherItems: Decodable {
     let item: [WeatherItem]
-    
 
     func requestWeatherDataSet(_ weatherItems: [WeatherItem]) -> [(time: String, iconName: String, temp: String, probability: String)] {
         var weatherData = [(time: String, iconName: String, temp: String, probability: String)]()
@@ -291,16 +290,9 @@ struct WeatherItems: Decodable {
     }
     
     private var current: (day: String, time: Int) {
-        let now = Date()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd HHmm"
-        formatter.locale = Locale(identifier: "ko_kr")
-        formatter.timeZone = TimeZone(abbreviation: "KST")
-
-        let currentDayAndTime = formatter.string(from: now).split(separator: " ")
-        let currentDay = String(currentDayAndTime[0])
-        let time = Int(currentDayAndTime[1])!
-        let calculatedTime = (time / 100) * 100
+        let currentDayAndTime = Date.currentWeatherTime
+        let currentDay = String(currentDayAndTime.days)
+        let calculatedTime = (currentDayAndTime.time / 100) * 100
         
         return (currentDay, calculatedTime)
     }
@@ -309,16 +301,7 @@ struct WeatherItems: Decodable {
         var filteredItem = [WeatherItem]()
         
         var currentHour: String {
-            let now = Date()
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyyMMdd HHmm"
-            formatter.locale = Locale(identifier: "ko_kr")
-            formatter.timeZone = TimeZone(abbreviation: "KST")
-            
-            let str = formatter.string(from: now)
-            let time = str.split(separator: " ").map{ Int($0)! }[1]
-            
-            let calculatedTime = (time / 100) * 100
+            let calculatedTime = current.time
             
             if calculatedTime == 0 {
                 return "0000"

--- a/BJGG/BJGG/Model/WeatherTime.swift
+++ b/BJGG/BJGG/Model/WeatherTime.swift
@@ -1,0 +1,12 @@
+//
+//  WeatherTime.swift
+//  BJGG
+//
+//  Created by 이재웅 on 2023/03/14.
+//
+
+import Foundation
+
+/// yyyyMMdd 형식의 days, HHmm 형식의 time을 가지는 튜플
+typealias WeatherTime = (days: Int, time: Int)
+

--- a/BJGG/BJGG/Network/WeatherManager.swift
+++ b/BJGG/BJGG/Network/WeatherManager.swift
@@ -13,57 +13,6 @@ enum WeatherManagerError: Error {
 }
 
 struct WeatherManager {
-    private let today: String = {
-        let now = Date()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd HHmm"
-        formatter.locale = Locale(identifier: "ko_kr")
-        formatter.timeZone = TimeZone(abbreviation: "KST")
-        
-        let str = formatter.string(from: now)
-        
-        let time = str.split(separator: " ").map{ Int($0)! }[1]
-        
-        switch time {
-        case 0..<300:
-            let day = str.split(separator: " ").map{ Int($0)! }[0]
-            return String(day-1)
-            
-        default:
-            return str.split(separator: " ").map{ String($0) }[0]
-        }
-    }()
-    
-    private let nowTime: String = {
-        let now = Date()
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMdd HHmm"
-        formatter.locale = Locale(identifier: "ko_kr")
-        formatter.timeZone = TimeZone(abbreviation: "KST")
-        
-        let str = formatter.string(from: now)
-        let time = str.split(separator: " ").map{ Int($0)! }[1]
-        
-        switch time {
-        case 300..<600:
-            return "0200"
-        case 600..<900:
-            return "0500"
-        case 900..<1200:
-            return "0800"
-        case 1200..<1500:
-            return "1100"
-        case 1500..<1800:
-            return "1400"
-        case 1800..<2100:
-            return "1700"
-        case 2100...2400:
-            return "2000"
-        default:
-            return "2300"
-        }
-    }()
-    
     private func requestWeather(nx: Int, ny: Int, numberOfRow: Int) async throws -> Weather {
         guard let privatePlist = Bundle.main.url(forResource: "Private", withExtension: "plist") else {
             throw PlistError.bundleError
@@ -74,7 +23,7 @@ struct WeatherManager {
         }
         
         let weatherAPIKey = dictionary["weatherAPIKey"] as! String
-        let urlString = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=\(weatherAPIKey)&numOfRows=\(numberOfRow)&pageNo=1&dataType=JSON&base_date=\(today)&base_time=\(nowTime)&nx=\(nx)&ny=\(ny)"
+        let urlString = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst?serviceKey=\(weatherAPIKey)&numOfRows=\(numberOfRow)&pageNo=1&dataType=JSON&base_date=\(Date.requestDay)&base_time=\(Date.requestTime)&nx=\(nx)&ny=\(ny)"
         
         guard let url = URL(string: urlString) else {
             throw PlistError.stringCastingError
@@ -164,4 +113,43 @@ struct WeatherManager {
 //            completionHandler(true, output.response)
 //        }.resume()
 //    }
+}
+
+fileprivate extension Date {
+    static var requestDay: String {
+        let date = Date.currentWeatherTime
+        let day = date.days
+        let time = date.time
+        
+        switch time {
+        case 0..<300:
+            return String(day-1)
+            
+        default:
+            return String(day)
+        }
+    }
+    
+    static var requestTime: String {
+        let time = Date.currentWeatherTime.time
+        
+        switch time {
+        case 300..<600:
+            return "0200"
+        case 600..<900:
+            return "0500"
+        case 900..<1200:
+            return "0800"
+        case 1200..<1500:
+            return "1100"
+        case 1500..<1800:
+            return "1400"
+        case 1800..<2100:
+            return "1700"
+        case 2100...2400:
+            return "2000"
+        default:
+            return "2300"
+        }
+    }
 }


### PR DESCRIPTION
## 작업사항
Weather, WeatherManager 내부에서 반복되는 날짜/시간 변수를 재사용 가능하도록 리팩토링 하였습니다.

1. `WeatherTime` 구현

```swift
/// yyyyMMdd 형식의 days, HHmm 형식의 time을 가지는 튜플
typealias WeatherTime = (days: Int, time: Int)
```

2. Date의 static 변수 구현

```swift
extension Date {
    /// 현재시간을 WeatherTime으로 반환하는 변수
    static var currentWeatherTime: WeatherTime {
        ...
        (변환로직)
        ...
        return WeatherTime(days, time)  
    }
}
``` 

## 이슈번호
- #175 

## 특이사항(Optional)
`WeatherItems`의 리팩토링 여부에 대한 확인이 필요합니다. 차후 진행될 여지가 있습니다.

close #175 