### PR TITLE
[2023/03/16] feat/liveStreamingVideoTextAnimation > 영상 로딩 페이지 애니메이션 부여

### DIFF
--- a/BJGG/BJGG.xcodeproj/project.pbxproj
+++ b/BJGG/BJGG.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		3AA636E329B390EE006BB5EF /* ScreenSizeControlButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E229B390EE006BB5EF /* ScreenSizeControlButton.swift */; };
 		3AA636E529B391FF006BB5EF /* LiveMarkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E429B391FF006BB5EF /* LiveMarkView.swift */; };
 		3AA636E729B4C8CA006BB5EF /* SpotLiveCameraGradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E629B4C8CA006BB5EF /* SpotLiveCameraGradientView.swift */; };
-		3AA636E929B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift */; };
+		3AA636E929B4DE6D006BB5EF /* SpotLiveCameraStandbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStandbyView.swift */; };
 		3AD87FB228D892D300ABD2E4 /* InfoDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD87FB128D892D300ABD2E4 /* InfoDescriptionView.swift */; };
 		42600D5928EF200B00D114BC /* Private.plist in Resources */ = {isa = PBXBuildFile; fileRef = 42600D5828EF200B00D114BC /* Private.plist */; };
 		42600D5F28EF322500D114BC /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 42600D5E28EF322500D114BC /* Settings.bundle */; };
@@ -75,7 +75,7 @@
 		3AA636E229B390EE006BB5EF /* ScreenSizeControlButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenSizeControlButton.swift; sourceTree = "<group>"; };
 		3AA636E429B391FF006BB5EF /* LiveMarkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveMarkView.swift; sourceTree = "<group>"; };
 		3AA636E629B4C8CA006BB5EF /* SpotLiveCameraGradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotLiveCameraGradientView.swift; sourceTree = "<group>"; };
-		3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotLiveCameraStanbyView.swift; sourceTree = "<group>"; };
+		3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStandbyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotLiveCameraStandbyView.swift; sourceTree = "<group>"; };
 		3AD87FB128D892D300ABD2E4 /* InfoDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoDescriptionView.swift; sourceTree = "<group>"; };
 		42600D5828EF200B00D114BC /* Private.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Private.plist; sourceTree = "<group>"; };
 		42600D5E28EF322500D114BC /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -149,7 +149,7 @@
 			isa = PBXGroup;
 			children = (
 				3A7E3BE428D766D700F6416A /* SpotLiveCameraView.swift */,
-				3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift */,
+				3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStandbyView.swift */,
 				3AA636E029B390B6006BB5EF /* SpotLiveCameraControlView.swift */,
 				3AA636E629B4C8CA006BB5EF /* SpotLiveCameraGradientView.swift */,
 				3AA636E229B390EE006BB5EF /* ScreenSizeControlButton.swift */,
@@ -380,7 +380,7 @@
 				553F0FA728E9E11E00FD9CDA /* Weather.swift in Sources */,
 				3A7E3BE528D766D700F6416A /* SpotLiveCameraView.swift in Sources */,
 				3A7E3BE328D7663300F6416A /* BbajiSpotViewController.swift in Sources */,
-				3AA636E929B4DE6D006BB5EF /* SpotLiveCameraStanbyView.swift in Sources */,
+				3AA636E929B4DE6D006BB5EF /* SpotLiveCameraStandbyView.swift in Sources */,
 				553F0FA128E4C58600FD9CDA /* ShadowGradientView.swift in Sources */,
 				55F0AE6129BF5DE4003B5EEE /* Date+Weather.swift in Sources */,
 				55CB0ABC28BB41C60045644C /* BbajiHomeViewController.swift in Sources */,

--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 import SnapKit
 
 final class BbajiSpotViewController: UIViewController {
+    
     private let liveCameraView = SpotLiveCameraView()
     private let infoScrollView = UIScrollView()
     private let infoScrollContentView = UIView()
@@ -178,12 +179,15 @@ final class BbajiSpotViewController: UIViewController {
     @objc private func toBackground() {
         firstAttempt = false
         liveMarkView.liveMarkActive(to: false)
+        liveCameraView.stanbyView.stopLoadingAnimation()
     }
     
     @objc private func toForeground() {
         if !firstAttempt {
             liveCameraView.playVideo()
-            liveCameraView.stanbyView.configureLayout()
+            liveCameraView.changeReloadButtonActiveStatus(as: false)
+            liveCameraView.stanbyView.reloadStandbyView()
+            
         }
     }
     

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraStanbyView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraStanbyView.swift
@@ -63,12 +63,18 @@ final class SpotLiveCameraStanbyView: UIView {
     
     private func configureComponent() {
         mainLabel.text = "물"
-        subLabel.text = "이 들어오는 중이예요"
         subLabel.text = "이 들어오는 중이에요"
         
         makeLoadingAnimation()
     }
     
+    func reloadStandbyView() {
+        self.alpha = 1.0
+        mainLabel.textColor = .bbagaBlue
+        UIView.animate(withDuration: 0.7, animations: {
+            self.backgroundColor = .black.withAlphaComponent(0.3)
+        })
+        makeLoadingAnimation()
     }
     
     func changeStandbyView(as status: AVPlayerItem.Status) {

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraStanbyView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraStanbyView.swift
@@ -10,15 +10,16 @@ import SnapKit
 import UIKit
 
 final class SpotLiveCameraStanbyView: UIView {
-
+    
     private let mainLabel = UILabel()
     private let subLabel = UILabel()
+    private var timer: Timer?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
     }
-
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
@@ -63,6 +64,11 @@ final class SpotLiveCameraStanbyView: UIView {
     private func configureComponent() {
         mainLabel.text = "물"
         subLabel.text = "이 들어오는 중이예요"
+        subLabel.text = "이 들어오는 중이에요"
+        
+        makeLoadingAnimation()
+    }
+    
     }
     
     func changeStandbyView(as status: AVPlayerItem.Status) {
@@ -76,5 +82,26 @@ final class SpotLiveCameraStanbyView: UIView {
             mainLabel.textColor = UIColor(rgb: 0x626262)
             subLabel.text = "을 불러오지 못했어요"
         }
+    }
+    
+    private func makeLoadingAnimation() {
+        let text = "이 들어오는 중이에요"
+        subLabel.text = "\(text)."
+        
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [self] (timer) in
+            var string: String {
+                switch subLabel.text {
+                case "\(text).":       return "\(text).."
+                case "\(text)..":      return "\(text)..."
+                case "\(text)...":     return "\(text)."
+                default:                return "\(text)"
+                }
+            }
+            subLabel.text = string
+        }
+    }
+    
+    func stopLoadingAnimation() {
+        timer?.invalidate()
     }
 }

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraStandbyView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraStandbyView.swift
@@ -1,5 +1,5 @@
 //
-//  SpotLiveCameraStanbyView.swift
+//  SpotLiveCameraStandbyView.swift
 //  BJGG
 //
 //  Created by 황정현 on 2023/03/05.
@@ -9,7 +9,7 @@ import AVFoundation
 import SnapKit
 import UIKit
 
-final class SpotLiveCameraStanbyView: UIView {
+final class SpotLiveCameraStandbyView: UIView {
     
     private let mainLabel = UILabel()
     private let subLabel = UILabel()

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
@@ -209,7 +209,7 @@ final class SpotLiveCameraView: UIView {
     @objc private func didPressReloadButton() {
         self.playVideo()
         changeReloadButtonActiveStatus(as: false)
-        stanbyView.configureLayout()
+        stanbyView.reloadStandbyView()
     }
 }
 

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
@@ -18,7 +18,7 @@ final class SpotLiveCameraView: UIView {
     var controlStatus: ControlStatus = .hidden
     
     var videoPlayerControlView: SpotLiveCameraControlView = SpotLiveCameraControlView()
-    var stanbyView: SpotLiveCameraStanbyView = SpotLiveCameraStanbyView()
+    var stanbyView: SpotLiveCameraStandbyView = SpotLiveCameraStandbyView()
     
     private let videoURL = BbajiInfo().getLiveCameraUrl()
     private let reloadButton: UIButton = UIButton()

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotLiveCameraView.swift
@@ -147,8 +147,9 @@ final class SpotLiveCameraView: UIView {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
             return
         }
-            
+        
         if keyPath == #keyPath(AVPlayerItem.status) {
+            
             let status: AVPlayerItem.Status
             if let statusNumber = change?[.newKey] as? NSNumber {
                 status = AVPlayerItem.Status(rawValue: statusNumber.intValue)!
@@ -164,10 +165,12 @@ final class SpotLiveCameraView: UIView {
                 delegate?.videoIsReadyToPlay()
                 player?.play()
             case .failed:
+                stanbyView.stopLoadingAnimation()
                 changeReloadButtonActiveStatus(as: true)
                 print(".failed")
             case .unknown:
                 print(".unknown")
+                stanbyView.stopLoadingAnimation()
                 changeReloadButtonActiveStatus(as: true)
             @unknown default:
                 print("@unknown default")

--- a/BJGG/BJGG/BbajiSpot/UI Component/SpotTodayWeatherCollectionViewCell.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/SpotTodayWeatherCollectionViewCell.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 final class SpotTodayWeatherCollectionViewCell: UICollectionViewCell {
+    
     private let currentRainPercentLabel = UILabel()
     private let currentWeatherImgView = UIImageView()
     private let temperatureLabel = UILabel()


### PR DESCRIPTION
## 작업사항
SpotLiveCameraView의 라이브 영상 로딩 시 띄우는 `LiveCameraStandbyView`에 애니메이션 효과를 부여했습니다.
|기본 텍스트 애니메이션 효과|Background -> Foreground 진입 시 <br>애니메이션|영상 호출 실패 -> 재호출 시 애니메이션|
|:---:|:---:|:---:|
|![](https://user-images.githubusercontent.com/96641477/225578153-25642b3c-db6e-4541-81ef-4fdb0d240859.mp4)|![](https://user-images.githubusercontent.com/96641477/225578186-34d4034b-bde5-4b99-b130-6d471dcef4c1.mp4)|![](https://user-images.githubusercontent.com/96641477/225578194-4ae8a009-bb51-4b5b-b274-5b1803c378d0.mp4)|

## 이슈번호
- #179 

## 특이사항(Optional)
- 텍스트 애니메이션 효과 구현과 함께 `LiveCameraStandbyView`의 애니메이션 효과 메소드를 수정했습니다.

Close #179 