### PR TITLE
[2023/06/25] fix/bbajiListCellShadow >> BbajiHomeViewController에서 앱이 백그라운드에 갔다 왔을 때 그림자 위치가 깨지는 오류 수정

### DIFF
--- a/BJGG/BJGG/BbajiHome/UI Component/BbajiListView/BbajiListCellShadowView.swift
+++ b/BJGG/BJGG/BbajiHome/UI Component/BbajiListView/BbajiListCellShadowView.swift
@@ -8,23 +8,26 @@
 import UIKit
 
 class BbajiListCellShadowView: UIView {
-    let color1 = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.8)
-    let color2 = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.6708)
-    let color3 = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
-    let gradient: CAGradientLayer = CAGradientLayer()
-    
-    override class var layerClass: AnyClass {
-        return CAGradientLayer.self
+    override func draw(_ rect: CGRect) {
+        drawGradientShadow(rect)
     }
     
-    override func layoutSubviews() {
-        let gradientLayer = layer as! CAGradientLayer
-        
-        gradientLayer.colors = [color1.cgColor, color2.cgColor, color3.cgColor]
-        gradientLayer.locations = [0.0, 0.6, 1.0]
-        gradientLayer.startPoint = CGPoint(x: 0.0, y: 1.0)
-        gradientLayer.endPoint = CGPoint(x: 0.0, y: 0.0)
-        gradientLayer.frame = CGRect(x: 0.0, y: bounds.height * 0.4, width: bounds.width, height: bounds.height * 0.6)
-        gradientLayer.cornerRadius = 4.0
+    private func drawGradientShadow(_ rect: CGRect) {
+        if layer.sublayers == nil {
+            let color1 = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.8)
+            let color2 = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.6708)
+            let color3 = UIColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+            
+            let gradientLayer = CAGradientLayer()
+            
+            gradientLayer.colors = [color1.cgColor, color2.cgColor, color3.cgColor]
+            gradientLayer.locations = [0.0, 0.6, 1.0]
+            gradientLayer.startPoint = CGPoint(x: 0.0, y: 1.0)
+            gradientLayer.endPoint = CGPoint(x: 0.0, y: 0.0)
+            gradientLayer.frame = CGRect(x: 0.0, y: rect.height * 0.4, width: rect.width, height: rect.height * 0.6)
+            gradientLayer.cornerRadius = 4.0
+            
+            layer.addSublayer(gradientLayer)
+        }
     }
 }


### PR DESCRIPTION
## 작업사항
- BbajiHomeViewController의 BbajiListCell에 있는 그림자 디자인이 앱이 백그라운드 상태에 있다 돌아오면 프레임이 깨지는 오류를 수정하였습니다.

|수정 전|수정 후|
|:-----:|:-----:|
|<img width="300" src="https://github.com/OFFTORIVER/BJGG/assets/83946704/2d7457b8-50a8-4d90-a96c-84353e9a3e3a">|<img width="300" src="https://github.com/OFFTORIVER/BJGG/assets/83946704/570f893b-dbf5-4429-8baa-1670352086d0">|

- 에러 원인 : **`layoutSubviews`에서 계산되는 그림자의 bounds 문제**

>[참고]
상위뷰 -> 특정 뷰를 subview로 가지고 있는 view
하위뷰 -> 특정 뷰의 subview로 존재하는 view

그림자 UI는 `BbajiListCell` 클래스의 하위 뷰인 `BbajiListCellShadowView` 클래스에서 그리고 있었습니다. 그리고 해당 로직은 `layoutSubviews()` 메소드를 오버라이드 하여 구현한 상태였습니다.

```swift
class BbajiListCellShadowView: UIView {
    let gradient: CAGradientLayer = CAGradientLayer()

    override class var layerClass: AnyClass {
        return CAGradientLayer.self

    override func layoutSubviews() {
        let gradientLayer = layer as! CAGradientLayer

        gradientLayer.colors = [color1.cgColor, color2.cgColor, color3.cgColor]
        gradientLayer.locations = [0.0, 0.6, 1.0]
        gradientLayer.startPoint = CGPoint(x: 0.0, y: 1.0)
        gradientLayer.endPoint = CGPoint(x: 0.0, y: 0.0)
        gradientLayer.frame = CGRect(x: 0.0, y: bounds.height * 0.4, width: bounds.width, height: bounds.height * 0.6)
        gradientLayer.cornerRadius = 4.0
   }
}
```

`layoutSubviews`메소드 내의 `gradientLayer.frame`에 값을 설정하는 코드에서 그림자의 width, height을 설정해주게 됩니다.

앱을 최초 실행하는 순간에는 Layout LifeCycle에 맞춰 가상 상위 View인 `BbajiHomeViewController`의 frame, bounds가 계산되고 이후에 하위 뷰인 `BbajiListView` -> `BbajiListCell` -> `BbajiListCellShadowView` 순서대로 frame과 bounds가 계산되게 됩니다.

|앱 최초 실행시 로그|
|:---------------:|
|<img width="247" alt="스크린샷 2023-06-27 오후 11 58 48" src="https://github.com/OFFTORIVER/BJGG/assets/83946704/00370ce9-6e4d-409d-a873-a8172eceac2f">|

(viewController -> `BbajiHomeViewController`의 bounds height, width)
(bounds -> `BbajiListCellShadowView`의 bounds height, width)

`BbajiHomeViewController`의 bounds print 시점 = `viewWillLayoutSubviews()`
`BbajiListCellShadowView`의 bounds print 시점 = `layoutSubviews()`

하지만 Background로 이동 시 아래와 같은 로그를 발견할 수 있습니다.
|Background로 이동 시 로그|
|:-----------------------:|
|<img width="211" alt="스크린샷 2023-06-28 오전 12 02 08" src="https://github.com/OFFTORIVER/BJGG/assets/83946704/913654ff-481d-46a4-9db1-1b17d3efc897">|

다음과 같이 `BbajiListCellShadowView`의 `layoutSubviews` 메소드가 ViewController Layout Cycle과 다르게 실행되어 예상과 다른 height로 계산되는 문제가 발생하였습니다.

그 이유에 있어선 다음과 같은 원인을 찾을 수 있었습니다.
1. iOS는 백그라운드로 이동할 때, 앱 스위처(App Switcher)에게 앱의 스냅샷을 전달하기 위해 화면의 크기를 재조정한다.
2. 그 순간 UIView의 `layoutSubviews`메소드가 실행된다.
3. 에러 발생


- 해결방법 : **그림자 드로잉 로직을 `layoutSubviews`에서 `draw(_:)`로 변경**
`draw(_:)`메소드는 모든 Layout Cycle이 동작한 후 마지막에 불리는 메소드입니다. 따라서 반드시 해당 View의 frame이 계산됨을 보장하고, background 상태로 앱이 전환될 시에도 크기를 유지합니다. 따라서 해당 메소드에서 그림자를 드로잉함으로 에러를 수정하였습니다.


## 이슈번호
- #147 

## 특이사항(Optional)
- 참고
- [iOS의 레이아웃 사이클](https://daeun28.github.io/이론/post22/)
- [Layout Cycle / The Deferred Layout Pass](https://zeddios.tistory.com/1202)
- [Background로 이동 시 layoutSubviews가 불리는 이유(스택오버플로우)](https://stackoverflow.com/questions/37487446/layoutsubviews-getting-called-repeatedly-when-the-app-enters-background-state)

이 외에 iOS의 Life Cycle도 참고하면 좋을 듯 합니다.

close #147 