### PR TITLE
[2023/11/17] feat/spotSegmentedControlUI >> BbajiSpot Segment Control 구현

### DIFF
--- a/BJGG/BJGG.xcodeproj/project.pbxproj
+++ b/BJGG/BJGG.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		3AA636E929B4DE6D006BB5EF /* SpotLiveCameraStandbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA636E829B4DE6D006BB5EF /* SpotLiveCameraStandbyView.swift */; };
 		3AB170812AF75C5E009A49A3 /* Private.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3AB170802AF75C5E009A49A3 /* Private.xcconfig */; };
 		3AB170822AF75C5E009A49A3 /* Private.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3AB170802AF75C5E009A49A3 /* Private.xcconfig */; };
+		3AC6DB062B05FFA60006BA4D /* UnderlineSegmentedControlView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AC6DB052B05FFA60006BA4D /* UnderlineSegmentedControlView.swift */; };
 		3AD87FB228D892D300ABD2E4 /* InfoDescriptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AD87FB128D892D300ABD2E4 /* InfoDescriptionView.swift */; };
 		3AF5BFC32AD7AA66004741CD /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AF5BFC22AD7AA66004741CD /* UIViewController+.swift */; };
 		42600D5F28EF322500D114BC /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 42600D5E28EF322500D114BC /* Settings.bundle */; };
@@ -135,6 +136,7 @@
 		3AB1707E2AF75C4C009A49A3 /* BJGG.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BJGG.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AB1707F2AF75C4C009A49A3 /* BJGGTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BJGGTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AB170802AF75C5E009A49A3 /* Private.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Private.xcconfig; sourceTree = "<group>"; };
+		3AC6DB052B05FFA60006BA4D /* UnderlineSegmentedControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnderlineSegmentedControlView.swift; sourceTree = "<group>"; };
 		3AD87FB128D892D300ABD2E4 /* InfoDescriptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoDescriptionView.swift; sourceTree = "<group>"; };
 		3AF5BFC22AD7AA66004741CD /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		42600D5E28EF322500D114BC /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
@@ -263,12 +265,12 @@
 		3A7E3BE028D7657800F6416A /* BbajiSpot */ = {
 			isa = PBXGroup;
 			children = (
+				3A7E3BE228D7663300F6416A /* BbajiSpotViewController.swift */,
 				3A1D45C32A46B94900DFA036 /* SpotWeatherViewModel.swift */,
 				3A1D45C12A46A66900DFA036 /* SpotLiveCameraViewModel.swift */,
 				3A53021729DC272300888CFA /* SpotViewModel.swift */,
 				3A1D45C52A46C2FC00DFA036 /* SpotInfoViewModel.swift */,
 				3A7E3BE128D765B500F6416A /* UI Component */,
-				3A7E3BE228D7663300F6416A /* BbajiSpotViewController.swift */,
 			);
 			path = BbajiSpot;
 			sourceTree = "<group>";
@@ -285,6 +287,7 @@
 				3AA636E429B391FF006BB5EF /* LiveMarkView.swift */,
 				3A7E3BE828D7670000F6416A /* SpotInfoView.swift */,
 				3AD87FB128D892D300ABD2E4 /* InfoDescriptionView.swift */,
+				3AC6DB052B05FFA60006BA4D /* UnderlineSegmentedControlView.swift */,
 				3A7E3BE628D766EC00F6416A /* SpotWeatherInfoView.swift */,
 				3A4A81F828EDB47600D1FA20 /* SpotWeatherAPIInfoView.swift */,
 				3A124ABB28DA037500D0EAA1 /* SpotTodayWeatherCollectionViewCell.swift */,
@@ -582,6 +585,7 @@
 				55CB0AA828BA4F9F0045644C /* AppDelegate.swift in Sources */,
 				06B1AFE92A6EA5F700CA712A /* ForecastManager.swift in Sources */,
 				3A124ABC28DA037500D0EAA1 /* SpotTodayWeatherCollectionViewCell.swift in Sources */,
+				3AC6DB062B05FFA60006BA4D /* UnderlineSegmentedControlView.swift in Sources */,
 				3AA636E129B390B6006BB5EF /* SpotLiveCameraControlView.swift in Sources */,
 				3A396BC029CC4D1C009B0545 /* NetworkManager.swift in Sources */,
 				06B1AFEC2A6EA8D400CA712A /* ComputableWeather.swift in Sources */,

--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -25,6 +25,17 @@ final class BbajiSpotViewController: UIViewController {
         return view
     }()
     
+    private var infoSegmentedControl: UnderlineSegmentedControlView = {
+        let view = UnderlineSegmentedControlView(items: [
+            "날씨/수온",
+            "운영",
+            "종목/가격",
+            "코치",
+            "보트"
+        ])
+        return view
+    }()
+    
     private var spotWeatherInfoView: SpotWeatherInfoView = {
         let view = SpotWeatherInfoView()
         view.backgroundColor = .bbagaGray4
@@ -38,7 +49,6 @@ final class BbajiSpotViewController: UIViewController {
     }()
     
     private var screenWidth: CGFloat = CGFloat()
-    private var firstAttempt: Bool = true
     
     private var infoViewModel: SpotInfoViewModel?
     var weatherViewModel: SpotWeatherViewModel?
@@ -145,13 +155,14 @@ final class BbajiSpotViewController: UIViewController {
             make.bottom.equalTo(infoScrollView.snp.bottom)
             make.centerX.equalTo(safeArea.snp.centerX)
             make.width.equalTo(safeArea.snp.width)
-            make.height.equalTo(UIDevice.current.hasNotch ? 631 : 631 - 32)
+            make.height.equalTo(UIDevice.current.hasNotch ? 674 : 674 - 32)
         }
         infoScrollView.showsVerticalScrollIndicator = false
         
         [
             spotInfoView,
             spotAvailableServiceView,
+            infoSegmentedControl,
             spotWeatherInfoView
         ].forEach { infoScrollContentView.addSubview($0) }
 
@@ -168,8 +179,15 @@ final class BbajiSpotViewController: UIViewController {
                 make.trailing.equalTo(infoScrollContentView.snp.trailing)
                 make.height.equalTo(123)
         }
-        spotWeatherInfoView.snp.makeConstraints { make in
+        
+        infoSegmentedControl.snp.makeConstraints { make in
+            make.horizontalEdges.equalTo(view.snp.horizontalEdges)
             make.top.equalTo(spotAvailableServiceView.snp.bottom).offset(BbajiConstraints.space6)
+            make.height.equalTo(43)
+        }
+        
+        spotWeatherInfoView.snp.makeConstraints { make in
+            make.top.equalTo(infoSegmentedControl.snp.bottom).offset(BbajiConstraints.space2)
             make.leading.equalTo(infoScrollContentView.snp.leading)
             make.trailing.equalTo(infoScrollContentView.snp.trailing)
             make.height.equalTo(UIDevice.current.hasNotch ? 311 : 295)

--- a/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
+++ b/BJGG/BJGG/BbajiSpot/BbajiSpotViewController.swift
@@ -26,7 +26,7 @@ final class BbajiSpotViewController: UIViewController {
     }()
     
     private var infoSegmentedControl: UnderlineSegmentedControlView = {
-        let view = UnderlineSegmentedControlView(items: [
+        let view = UnderlineSegmentedControlView(titleList: [
             "날씨/수온",
             "운영",
             "종목/가격",

--- a/BJGG/BJGG/BbajiSpot/UI Component/UnderlineSegmentedControlView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/UnderlineSegmentedControlView.swift
@@ -1,0 +1,172 @@
+//
+//  UnderlineSegmentedControlView.swift
+//  BJGG
+//
+//  Created by 황정현 on 11/16/23.
+//
+
+import Combine
+import CombineCocoa
+import SnapKit
+import UIKit
+
+final class UnderlineSegmentedControlView: UIView {
+    
+    private lazy var buttonStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .leading
+        stackView.distribution = .equalSpacing
+        stackView.spacing = stackViewSpacing
+        return stackView
+    }()
+    
+    private var underlineBackgroundView : UIView = {
+        let view = UIView()
+        view.backgroundColor = .bbagaBack
+        return view
+    }()
+    
+    private lazy var underlineView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .bbagaBlue
+        return view
+    }()
+    
+    private var segmentButtons: [UIButton] = []
+    private var segmentButtonsCenterXPositions: [CGFloat] = []
+    
+    private let underlineWidth: CGFloat = 28.0
+    private let underlineHeight: CGFloat = 2.0
+    private let stackViewSpacing: CGFloat = BbajiConstraints.space32
+    private let superViewInset = BbajiConstraints.space20
+    private var currentTotalItemWidth: CGFloat = 0
+    
+    private var selectedSegmentIndex = 0 {
+        didSet {
+            selectedSegmentPublisher.send(selectedSegmentIndex)
+        }
+    }
+    
+    private var selectedSegmentPublisher: PassthroughSubject<Int, Never> = PassthroughSubject<Int, Never>()
+    private var cancellables = Set<AnyCancellable>()
+    
+    var segmentTapPublisher: AnyPublisher<Int, Never> {
+        return selectedSegmentPublisher.eraseToAnyPublisher()
+    }
+    
+    init(items: [Any]?) {
+        super.init(frame: .zero)
+        configure()
+        configureSegments(items: items)
+        bind()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func configure() {
+        configureLayout()
+        configureStyle()
+    }
+    
+    private func configureLayout() {
+        addSubview(buttonStackView)
+        buttonStackView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(BbajiConstraints.space12)
+            make.leading.equalToSuperview().offset(BbajiConstraints.space20)
+            make.height.equalTo(17)
+        }
+        buttonStackView.sizeToFit()
+        
+        addSubview(underlineBackgroundView)
+        underlineBackgroundView.snp.makeConstraints { make in
+            make.top.equalTo(buttonStackView.snp.bottom).offset(BbajiConstraints.space12)
+            make.horizontalEdges.equalToSuperview()
+
+            make.height.equalTo(underlineHeight)
+        }
+        
+        addSubview(underlineView)
+        underlineView.snp.makeConstraints { make in
+            make.top.equalTo(buttonStackView.snp.bottom).offset(BbajiConstraints.space12)
+            make.leading.equalToSuperview().offset(superViewInset + 13)
+            make.width.equalTo(underlineWidth)
+            make.height.equalTo(underlineHeight)
+        }
+    }
+    
+    private func configureStyle() {
+        self.backgroundColor = .bbagaGray4
+    }
+    
+    private func configureSegments(items: [Any]?) {
+        items?.forEach { item in
+            if let title = item as? String {
+                let button = UIButton()
+                buttonStackView.addArrangedSubview(button)
+                configureButtonStyle(title: title, button: button)
+                configureUnderlineViewXPosition(button: button)
+                segmentButtons.append(button)
+            }
+        }
+    }
+    
+    private func configureButtonStyle(title: String, button: UIButton) {
+        button.setTitle(title, for: .normal)
+        button.setTitleColor(.bbagaGray2, for: .normal)
+        button.setTitleColor(.bbagaGray1, for: .selected)
+        button.titleLabel?.font = .bbajiFont(.body2)
+        button.sizeToFit()
+        
+        button.snp.makeConstraints { make in
+            make.centerY.equalTo(buttonStackView.snp.centerY)
+        }
+    }
+    
+    private func configureUnderlineViewXPosition(button: UIButton) {
+        let underlineDefaultX = (button.bounds.width - underlineWidth) / 2
+        var xPosition: CGFloat = superViewInset
+        if segmentButtonsCenterXPositions.isEmpty {
+            xPosition += underlineDefaultX
+        } else {
+            xPosition += currentTotalItemWidth + stackViewSpacing * CGFloat(segmentButtons.count) + underlineDefaultX
+        }
+        
+        currentTotalItemWidth += button.bounds.width
+        segmentButtonsCenterXPositions.append(xPosition)
+    }
+    
+    private func bind() {
+        Publishers.MergeMany(
+            segmentButtons.enumerated().map { (index, button) in
+                button.controlEventPublisher(for: .touchUpInside)
+                    .map { index }
+            }
+        ).sink { [weak self] index in
+            self?.selectedSegmentIndex = index
+            self?.changeButtonStyle(selectedSegmentIndex: index)
+            self?.animateUnderline(to: index)
+        }
+        .store(in: &cancellables)
+    }
+    
+    private func changeButtonStyle(selectedSegmentIndex: Int) {
+        segmentButtons.forEach { [weak self] button in
+            let isSelected = (button == self?.segmentButtons[selectedSegmentIndex])
+            button.titleLabel?.font = isSelected ? .bbajiFont(.body2) : .bbajiFont(.heading9)
+            button.isSelected = isSelected
+        }
+    }
+    
+    private func animateUnderline(to index: Int) {
+        UIView.animate(
+            withDuration: 0.1,
+            animations: { [weak self] in
+                guard let buttonsCenterXPositions = self?.segmentButtonsCenterXPositions else { return }
+                self?.underlineView.frame.origin.x = buttonsCenterXPositions[index]
+            }
+        )
+    }
+}

--- a/BJGG/BJGG/BbajiSpot/UI Component/UnderlineSegmentedControlView.swift
+++ b/BJGG/BJGG/BbajiSpot/UI Component/UnderlineSegmentedControlView.swift
@@ -55,10 +55,10 @@ final class UnderlineSegmentedControlView: UIView {
         return selectedSegmentPublisher.eraseToAnyPublisher()
     }
     
-    init(items: [Any]?) {
+    init(titleList: [String]?) {
         super.init(frame: .zero)
         configure()
-        configureSegments(items: items)
+        configureSegments(titleList: titleList)
         bind()
     }
     
@@ -101,15 +101,13 @@ final class UnderlineSegmentedControlView: UIView {
         self.backgroundColor = .bbagaGray4
     }
     
-    private func configureSegments(items: [Any]?) {
-        items?.forEach { item in
-            if let title = item as? String {
-                let button = UIButton()
-                buttonStackView.addArrangedSubview(button)
-                configureButtonStyle(title: title, button: button)
-                configureUnderlineViewXPosition(button: button)
-                segmentButtons.append(button)
-            }
+    private func configureSegments(titleList: [String]?) {
+        titleList?.forEach { title in
+            let button = UIButton()
+            buttonStackView.addArrangedSubview(button)
+            configureButtonStyle(title: title, button: button)
+            configureUnderlineViewXPosition(button: button)
+            segmentButtons.append(button)
         }
     }
     

--- a/BJGG/BJGG/Extension/UIFont+CustomFont.swift
+++ b/BJGG/BJGG/Extension/UIFont+CustomFont.swift
@@ -35,7 +35,9 @@ extension UIFont {
         case heading6
         case heading7
         case heading8
+        case heading9
         case body1
+        case body2
         case button1
         case rainyCaption
     }
@@ -58,8 +60,12 @@ extension UIFont {
             return UIFont(name: Pretendard.bold.rawValue, size: 20.0) ?? UIFont()
         case .heading8:
             return UIFont(name: Pretendard.bold.rawValue, size: 16.0) ?? UIFont()
+        case .heading9:
+            return UIFont(name: Pretendard.bold.rawValue, size: 14.0) ?? UIFont()
         case .body1:
             return UIFont(name: Pretendard.medium.rawValue, size: 15.0) ?? UIFont()
+        case .body2:
+            return UIFont(name: Pretendard.medium.rawValue, size: 14.0) ?? UIFont()
         case .button1:
             return UIFont(name: Pretendard.medium.rawValue, size: 15.0) ?? UIFont()
         case .rainyCaption:

--- a/BJGG/BJGG/Utilities/Constraints.swift
+++ b/BJGG/BJGG/Utilities/Constraints.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 final class BbajiConstraints {
+    static let space2: CGFloat = 2.0
     // label 간 간격 constraint
     static let space4: CGFloat = 4.0
     
@@ -29,6 +30,8 @@ final class BbajiConstraints {
     static let viewInset: CGFloat = UIDevice.current.hasNotch ? 20.0 : 16.0
     
     static let space20: CGFloat = 20.0
+    
+    static let space32: CGFloat = 32.0
     
     private init() { }
 }


### PR DESCRIPTION
## 작업사항
**BbajiSpot 하단에서 사용되는 Segment Control 구현**

|실행 영상|
|:---:|
|![](https://github.com/OFFTORIVER/BJGG/assets/96641477/53160115-883e-4c61-aafd-a8b5d6f7e67e)|

### 코드 설명
기존의 UISegmentedControl을 사용할 경우 디자인 요청사항의 Left Alignment 형태 반영이 불가하여 UIView를 통한 CustomSegmentedControl을 만들었습니다.

- UIButton과 같이 사용자의 액션에 대한 처리를 하는 기본 UI Component의 구조를 참고하여 Combine의 Publisher 형태로 클릭한 Segment의 Index를 방출하는 형태로 구현했습니다.

```swift
    private var selectedSegmentIndex = 0 {
        didSet {
            selectedSegmentPublisher.send(selectedSegmentIndex)
        }
    }

    private var selectedSegmentPublisher: PassthroughSubject<Int, Never> = PassthroughSubject<Int, Never>()
    private var cancellables = Set<AnyCancellable>()
    
    var segmentTapPublisher: AnyPublisher<Int, Never> {
        return selectedSegmentPublisher.eraseToAnyPublisher()
    }
```

- Segment는 사용자가 입력하는 item의 수만큼의 `UIButton`으로 등록되며, 눌린 버튼의 index를 전달받아 뷰의 Segment 색상, 폰트와 같은 디자인 요소를 수정합니다.
```swift
    private func bind() {
        Publishers.MergeMany(
            segmentButtons.enumerated().map { (index, button) in
                button.controlEventPublisher(for: .touchUpInside)
                    .map { index }
            }
        ).sink { [weak self] index in
            self?.selectedSegmentIndex = index
            self?.changeButtonStyle(selectedSegmentIndex: index)
            self?.animateUnderline(to: index)
        }
        .store(in: &cancellables)
    }
```



## 이슈번호
- #216 

## 특이사항(Optional)
- Segment 클릭 시 특정 뷰로의 이동 기능은 Segment Control 하위 뷰 작업이 완료된 후 구현될 예정입니다.

Close #216 